### PR TITLE
Add core gameplay systems, data models, UI, save, input, AI and platform readiness

### DIFF
--- a/Assets/Scripts/Core/Camera/CameraShake.cs
+++ b/Assets/Scripts/Core/Camera/CameraShake.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using UnityEngine;
+
+namespace TinyHunter.Core.Camera
+{
+    public class CameraShake : MonoBehaviour
+    {
+        private Vector3 defaultLocalPosition;
+
+        private void Awake()
+        {
+            defaultLocalPosition = transform.localPosition;
+        }
+
+        public void Shake(float intensity, float duration)
+        {
+            StopAllCoroutines();
+            StartCoroutine(ShakeCoroutine(intensity, duration));
+        }
+
+        private IEnumerator ShakeCoroutine(float intensity, float duration)
+        {
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                transform.localPosition = defaultLocalPosition + Random.insideUnitSphere * intensity;
+                yield return null;
+            }
+
+            transform.localPosition = defaultLocalPosition;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Camera/ThirdPersonCameraController.cs
+++ b/Assets/Scripts/Core/Camera/ThirdPersonCameraController.cs
@@ -1,0 +1,34 @@
+using TinyHunter.Core.Input;
+using UnityEngine;
+
+namespace TinyHunter.Core.Camera
+{
+    public class ThirdPersonCameraController : MonoBehaviour
+    {
+        [SerializeField] private Transform target;
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private Vector3 offset = new(0f, 1.2f, -2.5f);
+        [SerializeField] private float smoothSpeed = 8f;
+        [SerializeField] private float lookSensitivity = 120f;
+        [SerializeField] private float minPitch = -20f;
+        [SerializeField] private float maxPitch = 45f;
+
+        private float yaw;
+        private float pitch = 20f;
+
+        private void LateUpdate()
+        {
+            if (target == null || input == null) return;
+
+            var look = input.Look;
+            yaw += look.x * lookSensitivity * Time.deltaTime;
+            pitch -= look.y * lookSensitivity * Time.deltaTime;
+            pitch = Mathf.Clamp(pitch, minPitch, maxPitch);
+
+            Quaternion rotation = Quaternion.Euler(pitch, yaw, 0f);
+            Vector3 desiredPosition = target.position + rotation * offset;
+            transform.position = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed * Time.deltaTime);
+            transform.LookAt(target.position + Vector3.up * 0.5f);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Character/CharacterAppearanceData.cs
+++ b/Assets/Scripts/Core/Character/CharacterAppearanceData.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEngine;
+
+namespace TinyHunter.Core.Character
+{
+    [Serializable]
+    public class CharacterAppearanceData
+    {
+        public string CharacterName = "Hunter";
+        [Tooltip("0=Male, 1=Female")]
+        public int SexIndex;
+        [Tooltip("0=Normal, 1=Slim, 2=Strong, 3=Heavy")]
+        public int BodyTypeIndex;
+        public int HeadPresetIndex;
+        public int HairPresetIndex;
+        public int SkinToneIndex;
+        public int HairColorIndex;
+
+        public static CharacterAppearanceData Default()
+        {
+            return new CharacterAppearanceData
+            {
+                CharacterName = "Hunter",
+                SexIndex = 0,
+                BodyTypeIndex = 0,
+                HeadPresetIndex = 0,
+                HairPresetIndex = 0,
+                SkinToneIndex = 0,
+                HairColorIndex = 0
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Core/Character/CharacterCustomizer.cs
+++ b/Assets/Scripts/Core/Character/CharacterCustomizer.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Character
+{
+    public class CharacterCustomizer : MonoBehaviour
+    {
+        [Header("Future Visual Roots")]
+        [SerializeField] private Transform bodyRoot;
+        [SerializeField] private Transform headRoot;
+        [SerializeField] private Transform hairSocket;
+
+        [Header("Future Preset Prefabs (Dormant)")]
+        [SerializeField] private GameObject[] maleBodyPresets;
+        [SerializeField] private GameObject[] femaleBodyPresets;
+        [SerializeField] private GameObject[] headPresets;
+        [SerializeField] private GameObject[] hairPresets;
+
+        [Header("Future Materials")]
+        [SerializeField] private Renderer[] skinRenderers;
+        [SerializeField] private Renderer[] hairRenderers;
+        [SerializeField] private Color[] skinTonePalette;
+        [SerializeField] private Color[] hairColorPalette;
+
+        [Header("Safety")]
+        [SerializeField] private bool applyOnStart;
+
+        [SerializeField] private CharacterAppearanceData debugAppearance = CharacterAppearanceData.Default();
+
+        private void Start()
+        {
+            if (!applyOnStart) return;
+            ApplyAppearance(debugAppearance);
+        }
+
+        public void ApplyAppearance(CharacterAppearanceData appearance)
+        {
+            if (appearance == null) return;
+
+            // Dormant foundation:
+            // 1) Body preset by SexIndex + BodyTypeIndex
+            // 2) Head preset by HeadPresetIndex
+            // 3) Hair preset by HairPresetIndex
+            // 4) Skin/hair material colors by palette index
+            // This currently validates indices and applies only colors to avoid affecting active MVP flow.
+
+            ApplySkinColor(appearance.SkinToneIndex);
+            ApplyHairColor(appearance.HairColorIndex);
+        }
+
+        public void ApplySkinColor(int index)
+        {
+            if (skinTonePalette == null || skinTonePalette.Length == 0) return;
+            index = Mathf.Clamp(index, 0, skinTonePalette.Length - 1);
+            var color = skinTonePalette[index];
+
+            foreach (var rendererRef in skinRenderers)
+            {
+                if (rendererRef == null || rendererRef.material == null) continue;
+                rendererRef.material.color = color;
+            }
+        }
+
+        public void ApplyHairColor(int index)
+        {
+            if (hairColorPalette == null || hairColorPalette.Length == 0) return;
+            index = Mathf.Clamp(index, 0, hairColorPalette.Length - 1);
+            var color = hairColorPalette[index];
+
+            foreach (var rendererRef in hairRenderers)
+            {
+                if (rendererRef == null || rendererRef.material == null) continue;
+                rendererRef.material.color = color;
+            }
+        }
+
+        public void ApplyAppearanceFromProfile(PlayerProfileData profile)
+        {
+            if (profile == null) return;
+            ApplyAppearance(profile.Appearance);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Character/PlayerProfileData.cs
+++ b/Assets/Scripts/Core/Character/PlayerProfileData.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TinyHunter.Core.Character
+{
+    [Serializable]
+    public class PlayerProfileData
+    {
+        public CharacterAppearanceData Appearance = CharacterAppearanceData.Default();
+    }
+}

--- a/Assets/Scripts/Core/Combat/HitFeedbackSystem.cs
+++ b/Assets/Scripts/Core/Combat/HitFeedbackSystem.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using TinyHunter.Core.Camera;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class HitFeedbackSystem : MonoBehaviour
+    {
+        public static HitFeedbackSystem Instance { get; private set; }
+
+        [SerializeField] private float hitStopDuration = 0.03f;
+        [SerializeField] private CameraShake cameraShake;
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        public void PlayHitFeedback(float shakeIntensity = 0.08f, float shakeTime = 0.08f)
+        {
+            StartCoroutine(HitStopCoroutine(hitStopDuration));
+            if (cameraShake != null)
+            {
+                cameraShake.Shake(shakeIntensity, shakeTime);
+            }
+        }
+
+        private IEnumerator HitStopCoroutine(float duration)
+        {
+            Time.timeScale = 0f;
+            yield return new WaitForSecondsRealtime(duration);
+            Time.timeScale = 1f;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Combat/IDamageable.cs
+++ b/Assets/Scripts/Core/Combat/IDamageable.cs
@@ -1,0 +1,10 @@
+using TinyHunter.Data.Combat;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public interface IDamageable
+    {
+        void TakeHit(float damage, DamageType damageType, string hitPartId = null, Vector3? hitPoint = null);
+    }
+}

--- a/Assets/Scripts/Core/Combat/MonsterHealth.cs
+++ b/Assets/Scripts/Core/Combat/MonsterHealth.cs
@@ -1,0 +1,86 @@
+using TinyHunter.Core.Inventory;
+using TinyHunter.Core.Quest;
+using TinyHunter.Data.Combat;
+using TinyHunter.Data.Monsters;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    [RequireComponent(typeof(MonsterPartBreakSystem))]
+    public class MonsterHealth : MonoBehaviour, IDamageable
+    {
+        [SerializeField] private MonsterDefinition definition;
+        [SerializeField] private QuestSystem questSystem;
+        [SerializeField] private DebugChecklistUI checklist;
+        [SerializeField] private GameObject fallbackPickupPrefab;
+
+        private MonsterPartBreakSystem partBreakSystem;
+        private float currentHealth;
+
+        private void Awake()
+        {
+            currentHealth = definition.MaxHealth;
+            partBreakSystem = GetComponent<MonsterPartBreakSystem>();
+            partBreakSystem.OnPartBroken += OnPartBroken;
+        }
+
+        public void TakeHit(float damage, DamageType damageType, string hitPartId = null, Vector3? hitPoint = null)
+        {
+            if (damageType == definition.Weakness)
+            {
+                damage *= 1.25f;
+            }
+
+            currentHealth -= damage;
+            if (!string.IsNullOrEmpty(hitPartId) && partBreakSystem.HasPart(hitPartId))
+            {
+                partBreakSystem.ApplyPartDamage(hitPartId, damage);
+            }
+
+            if (currentHealth <= 0f)
+            {
+                Defeat();
+            }
+        }
+
+        private void OnPartBroken(MonsterPartDefinition part)
+        {
+            if (part.GuaranteedDrop != null)
+            {
+                SpawnPickup(part.GuaranteedDrop, part.GuaranteedDropAmount);
+            }
+        }
+
+        private void Defeat()
+        {
+            if (definition.LootTable != null)
+            {
+                foreach (var entry in definition.LootTable.Entries)
+                {
+                    if (Random.value > entry.DropChance || entry.Item == null) continue;
+                    int amount = Random.Range(entry.MinAmount, entry.MaxAmount + 1);
+                    SpawnPickup(entry.Item, amount);
+                }
+            }
+
+            checklist?.SetKilledTarget();
+            questSystem?.RegisterTargetDefeated(definition.MonsterId);
+            Destroy(gameObject);
+        }
+
+        private void SpawnPickup(Data.Items.ItemDefinition item, int amount)
+        {
+            GameObject pickupPrefab = item.WorldPickupPrefab != null ? item.WorldPickupPrefab : fallbackPickupPrefab;
+            if (pickupPrefab == null) return;
+
+            Vector3 spawnPos = transform.position + Random.insideUnitSphere * 0.3f;
+            spawnPos.y = transform.position.y + 0.1f;
+            var pickupObj = Instantiate(pickupPrefab, spawnPos, Quaternion.identity);
+            if (pickupObj.TryGetComponent<WorldPickup>(out var pickup))
+            {
+                pickup.Setup(item, amount);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Combat/MonsterPartBreakSystem.cs
+++ b/Assets/Scripts/Core/Combat/MonsterPartBreakSystem.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using TinyHunter.Data.Monsters;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class MonsterPartBreakSystem : MonoBehaviour
+    {
+        [System.Serializable]
+        private class PartState
+        {
+            public MonsterPartDefinition Definition;
+            public float CurrentDurability;
+            public bool IsBroken;
+        }
+
+        [SerializeField] private MonsterDefinition monsterDefinition;
+        [SerializeField] private bool debugPartBreakLogs = true;
+        private readonly Dictionary<string, PartState> partStates = new();
+
+        public delegate void PartBrokenHandler(MonsterPartDefinition part);
+        public event PartBrokenHandler OnPartBroken;
+
+        private void Awake()
+        {
+            foreach (var part in monsterDefinition.BreakableParts)
+            {
+                partStates[part.PartId] = new PartState
+                {
+                    Definition = part,
+                    CurrentDurability = part.MaxDurability,
+                    IsBroken = false
+                };
+            }
+        }
+
+        public void ApplyPartDamage(string partId, float damage)
+        {
+            if (!partStates.TryGetValue(partId, out var partState) || partState.IsBroken)
+            {
+                return;
+            }
+
+            partState.CurrentDurability -= damage * partState.Definition.BreakDamageMultiplier;
+            if (partState.CurrentDurability > 0f) return;
+
+            partState.IsBroken = true;
+            if (debugPartBreakLogs)
+            {
+                Debug.Log($"Part broken: {partState.Definition.DisplayName} ({partState.Definition.PartId})");
+            }
+
+            OnPartBroken?.Invoke(partState.Definition);
+        }
+
+        public bool HasPart(string partId) => partStates.ContainsKey(partId);
+    }
+}

--- a/Assets/Scripts/Core/Combat/MonsterPartHitbox.cs
+++ b/Assets/Scripts/Core/Combat/MonsterPartHitbox.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class MonsterPartHitbox : MonoBehaviour
+    {
+        [SerializeField] private string partId;
+        public string PartId => partId;
+    }
+}

--- a/Assets/Scripts/Core/Combat/PlayerStats.cs
+++ b/Assets/Scripts/Core/Combat/PlayerStats.cs
@@ -1,0 +1,79 @@
+using System;
+using TinyHunter.Core.Player;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class PlayerStats : MonoBehaviour
+    {
+        public float MaxHealth = 100f;
+        public float MaxStamina = 100f;
+        public float Defense = 5f;
+        public float MoveSpeed = 2.2f;
+        public float DodgeEfficiency = 1f;
+
+        public float CurrentHealth { get; private set; }
+        public float CurrentStamina { get; private set; }
+        public bool IsDead => CurrentHealth <= 0f;
+        public bool IsBlocking { get; private set; }
+        public float GuardReduction { get; private set; } = 0.5f;
+
+        public event Action<float, float> OnHealthChanged;
+        public event Action<float, float> OnStaminaChanged;
+
+        [SerializeField] private PlayerAnimationBridge animationBridge;
+
+        private void Awake()
+        {
+            CurrentHealth = MaxHealth;
+            CurrentStamina = MaxStamina;
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+            OnStaminaChanged?.Invoke(CurrentStamina, MaxStamina);
+        }
+
+        public void SetBlocking(bool blocking, float guardReduction)
+        {
+            IsBlocking = blocking;
+            GuardReduction = Mathf.Clamp01(guardReduction);
+        }
+
+        public bool SpendStamina(float amount)
+        {
+            if (CurrentStamina < amount) return false;
+            CurrentStamina -= amount;
+            OnStaminaChanged?.Invoke(CurrentStamina, MaxStamina);
+            return true;
+        }
+
+        public void RegenerateStamina(float rate)
+        {
+            CurrentStamina = Mathf.Min(MaxStamina, CurrentStamina + rate * Time.deltaTime);
+            OnStaminaChanged?.Invoke(CurrentStamina, MaxStamina);
+        }
+
+        public void ApplyDamage(float rawDamage)
+        {
+            var preDefense = IsBlocking ? rawDamage * (1f - GuardReduction) : rawDamage;
+            var damage = Mathf.Max(1f, preDefense - Defense);
+            CurrentHealth -= damage;
+            CurrentHealth = Mathf.Max(0f, CurrentHealth);
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+
+            if (CurrentHealth <= 0f)
+            {
+                animationBridge?.TriggerDeath();
+                return;
+            }
+
+            animationBridge?.TriggerHit();
+        }
+
+        public void RestoreToFull()
+        {
+            CurrentHealth = MaxHealth;
+            CurrentStamina = MaxStamina;
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+            OnStaminaChanged?.Invoke(CurrentStamina, MaxStamina);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Combat/TargetLockSystem.cs
+++ b/Assets/Scripts/Core/Combat/TargetLockSystem.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class TargetLockSystem : MonoBehaviour
+    {
+        [SerializeField] private Transform owner;
+        [SerializeField] private float lockRadius = 12f;
+        [SerializeField] private LayerMask targetMask;
+        public Transform CurrentTarget { get; private set; }
+
+        public void ToggleLock()
+        {
+            if (CurrentTarget != null)
+            {
+                CurrentTarget = null;
+                return;
+            }
+
+            Collider[] hits = Physics.OverlapSphere(owner != null ? owner.position : transform.position, lockRadius, targetMask);
+            float bestDistance = float.MaxValue;
+            Transform bestTarget = null;
+
+            foreach (var hit in hits)
+            {
+                float distance = Vector3.Distance(transform.position, hit.transform.position);
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    bestTarget = hit.transform;
+                }
+            }
+
+            CurrentTarget = bestTarget;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Combat/WeaponCombatSystem.cs
+++ b/Assets/Scripts/Core/Combat/WeaponCombatSystem.cs
@@ -1,0 +1,73 @@
+using TinyHunter.Core.Equipment;
+using TinyHunter.Core.Input;
+using TinyHunter.Core.Player;
+using TinyHunter.Data.Combat;
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Core.Combat
+{
+    public class WeaponCombatSystem : MonoBehaviour
+    {
+        [SerializeField] private PlayerController playerController;
+        [SerializeField] private PlayerStats playerStats;
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private PlayerAnimationBridge animationBridge;
+        [SerializeField] private EquipmentSystem equipmentSystem;
+        [SerializeField] private WeaponDefinition fallbackWeapon;
+        [SerializeField] private float attackRadius = 0.9f;
+        [SerializeField] private float attackStateDuration = 0.25f;
+        [SerializeField] private LayerMask hittableMask;
+
+        private WeaponDefinition EquippedWeapon => equipmentSystem != null && equipmentSystem.EquippedWeapon != null
+            ? equipmentSystem.EquippedWeapon
+            : fallbackWeapon;
+
+        private void Update()
+        {
+            var weapon = EquippedWeapon;
+            if (weapon == null || playerStats == null || input == null || playerController == null || playerStats.IsDead) return;
+
+            bool canGuard = weapon.CanBlock && playerController.CanAct();
+            playerStats.SetBlocking(canGuard && input.GuardHeld, weapon.GuardDamageReduction);
+
+            if (!playerController.CanAct()) return;
+
+            if (input.PrimaryAttackPressed)
+            {
+                TryAttack(AttackWeight.Light);
+            }
+        }
+
+        private void TryAttack(AttackWeight weight)
+        {
+            var weapon = EquippedWeapon;
+            if (weapon == null) return;
+
+            float staminaCost = weight == AttackWeight.Light ? weapon.StaminaCostLight : weapon.StaminaCostHeavy;
+            if (!playerStats.SpendStamina(staminaCost)) return;
+
+            playerController.SetAttackState(attackStateDuration);
+            if (weight == AttackWeight.Light) animationBridge?.TriggerLightAttack();
+            else animationBridge?.TriggerHeavyAttack();
+
+            float damageMultiplier = weight == AttackWeight.Light ? 1f : 1.8f;
+            float damage = weapon.AttackPower * damageMultiplier;
+
+            var hits = Physics.OverlapSphere(transform.position + transform.forward * weapon.Reach, attackRadius, hittableMask);
+            foreach (var hit in hits)
+            {
+                if (!hit.TryGetComponent<IDamageable>(out var target)) continue;
+
+                string partId = null;
+                if (hit.TryGetComponent<MonsterPartHitbox>(out var partHitbox))
+                {
+                    partId = partHitbox.PartId;
+                }
+
+                target.TakeHit(damage, weapon.DamageType, partId, hit.ClosestPoint(transform.position));
+                HitFeedbackSystem.Instance?.PlayHitFeedback();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Crafting/CraftingSystem.cs
+++ b/Assets/Scripts/Core/Crafting/CraftingSystem.cs
@@ -1,0 +1,41 @@
+using System;
+using TinyHunter.Core.Inventory;
+using TinyHunter.Data.Crafting;
+using UnityEngine;
+
+namespace TinyHunter.Core.Crafting
+{
+    public class CraftingSystem : MonoBehaviour
+    {
+        [SerializeField] private InventorySystem inventory;
+
+        public event Action<CraftingRecipeDefinition> OnCrafted;
+
+        public bool CanCraft(CraftingRecipeDefinition recipe)
+        {
+            foreach (var cost in recipe.Costs)
+            {
+                if (!inventory.HasItem(cost.Item, cost.Amount))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool Craft(CraftingRecipeDefinition recipe)
+        {
+            if (!CanCraft(recipe)) return false;
+
+            foreach (var cost in recipe.Costs)
+            {
+                inventory.RemoveItem(cost.Item, cost.Amount);
+            }
+
+            inventory.AddItem(recipe.OutputItem, recipe.OutputAmount);
+            OnCrafted?.Invoke(recipe);
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Equipment/EquipmentSystem.cs
+++ b/Assets/Scripts/Core/Equipment/EquipmentSystem.cs
@@ -1,0 +1,31 @@
+using System;
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Core.Equipment
+{
+    public class EquipmentSystem : MonoBehaviour
+    {
+        public WeaponDefinition EquippedWeapon { get; private set; }
+        public ArmorDefinition EquippedHead { get; private set; }
+
+        public event Action OnEquipmentChanged;
+
+        public void EquipWeapon(WeaponDefinition weapon)
+        {
+            EquippedWeapon = weapon;
+            OnEquipmentChanged?.Invoke();
+        }
+
+        public void EquipArmor(ArmorDefinition armor)
+        {
+            if (armor == null) return;
+            if (armor.Slot == ArmorSlot.Head)
+            {
+                EquippedHead = armor;
+            }
+
+            OnEquipmentChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Flow/EnterHuntInteractable.cs
+++ b/Assets/Scripts/Core/Flow/EnterHuntInteractable.cs
@@ -1,0 +1,19 @@
+using TinyHunter.Core.Interaction;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Flow
+{
+    public class EnterHuntInteractable : MonoBehaviour, IInteractable
+    {
+        [SerializeField] private DebugChecklistUI checklist;
+
+        public string GetInteractionText() => "Depart to Kitchen Hunt";
+
+        public void Interact()
+        {
+            checklist?.SetEnteredHunt();
+            SceneFlowController.Instance.EnterHunt();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Flow/HuntExitTrigger.cs
+++ b/Assets/Scripts/Core/Flow/HuntExitTrigger.cs
@@ -1,0 +1,17 @@
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Flow
+{
+    public class HuntExitTrigger : MonoBehaviour
+    {
+        [SerializeField] private DebugChecklistUI checklist;
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (other.GetComponent<TinyHunter.Core.Player.PlayerController>() == null) return;
+            checklist?.SetReturnedHub();
+            SceneFlowController.Instance.ReturnToHub();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Flow/MainMenuController.cs
+++ b/Assets/Scripts/Core/Flow/MainMenuController.cs
@@ -1,0 +1,18 @@
+using TinyHunter.Core.Save;
+using UnityEngine;
+
+namespace TinyHunter.Core.Flow
+{
+    public class MainMenuController : MonoBehaviour
+    {
+        [SerializeField] private SaveSystem saveSystem;
+
+        public void StartGame() => SceneFlowController.Instance.StartNewGame();
+
+        public void ContinueGame() => SceneFlowController.Instance.ContinueGame();
+
+        public bool CanContinue() => saveSystem != null && saveSystem.HasSave();
+
+        public void QuitGame() => Application.Quit();
+    }
+}

--- a/Assets/Scripts/Core/Flow/SceneFlowController.cs
+++ b/Assets/Scripts/Core/Flow/SceneFlowController.cs
@@ -1,0 +1,56 @@
+using TinyHunter.Core.Save;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace TinyHunter.Core.Flow
+{
+    public class SceneFlowController : MonoBehaviour
+    {
+        public static SceneFlowController Instance { get; private set; }
+
+        [SerializeField] private string mainMenuScene = "MainMenu";
+        [SerializeField] private string hubScene = "Hub_MVP";
+        [SerializeField] private string huntScene = "Kitchen_MVP";
+
+        private bool loadOnHubEnter;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        private void OnDestroy()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (scene.name == hubScene && loadOnHubEnter)
+            {
+                SaveSystem.Instance?.LoadGame();
+                loadOnHubEnter = false;
+            }
+        }
+
+        public void GoToMainMenu() => SceneManager.LoadScene(mainMenuScene);
+        public void StartNewGame() => SceneManager.LoadScene(hubScene);
+
+        public void ContinueGame()
+        {
+            loadOnHubEnter = true;
+            SceneManager.LoadScene(hubScene);
+        }
+
+        public void EnterHunt() => SceneManager.LoadScene(huntScene);
+        public void ReturnToHub() => SceneManager.LoadScene(hubScene);
+    }
+}

--- a/Assets/Scripts/Core/Input/DesktopInputSource.cs
+++ b/Assets/Scripts/Core/Input/DesktopInputSource.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Input
+{
+    public class DesktopInputSource : MonoBehaviour, IGameInputSource
+    {
+        public Vector2 Move => new(UnityEngine.Input.GetAxisRaw("Horizontal"), UnityEngine.Input.GetAxisRaw("Vertical"));
+        public Vector2 Look => new(UnityEngine.Input.GetAxis("Mouse X"), UnityEngine.Input.GetAxis("Mouse Y"));
+
+        public bool JumpPressed => UnityEngine.Input.GetKeyDown(KeyCode.Space);
+        public bool CrouchTogglePressed => UnityEngine.Input.GetKeyDown(KeyCode.C);
+        public bool DodgePressed => UnityEngine.Input.GetKeyDown(KeyCode.LeftShift);
+        public bool InteractPressed => UnityEngine.Input.GetKeyDown(KeyCode.E);
+        public bool PrimaryAttackPressed => UnityEngine.Input.GetMouseButtonDown(0);
+        public bool GuardHeld => UnityEngine.Input.GetMouseButton(1);
+        public bool LockTogglePressed => UnityEngine.Input.GetKeyDown(KeyCode.R);
+        public bool InventoryTogglePressed => UnityEngine.Input.GetKeyDown(KeyCode.Tab);
+        public bool EscapePressed => UnityEngine.Input.GetKeyDown(KeyCode.Escape);
+        public bool SavePressed => UnityEngine.Input.GetKeyDown(KeyCode.F5);
+        public bool LoadPressed => UnityEngine.Input.GetKeyDown(KeyCode.F9);
+    }
+}

--- a/Assets/Scripts/Core/Input/IGameInputSource.cs
+++ b/Assets/Scripts/Core/Input/IGameInputSource.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Input
+{
+    public interface IGameInputSource
+    {
+        Vector2 Move { get; }
+        Vector2 Look { get; }
+
+        bool JumpPressed { get; }
+        bool CrouchTogglePressed { get; }
+        bool DodgePressed { get; }
+        bool InteractPressed { get; }
+        bool PrimaryAttackPressed { get; }
+        bool GuardHeld { get; }
+        bool LockTogglePressed { get; }
+        bool InventoryTogglePressed { get; }
+        bool EscapePressed { get; }
+        bool SavePressed { get; }
+        bool LoadPressed { get; }
+    }
+}

--- a/Assets/Scripts/Core/Input/MobileInputSourceStub.cs
+++ b/Assets/Scripts/Core/Input/MobileInputSourceStub.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Input
+{
+    public class MobileInputSourceStub : MonoBehaviour, IGameInputSource
+    {
+        public Vector2 Move { get; private set; }
+        public Vector2 Look { get; private set; }
+
+        public bool JumpPressed { get; private set; }
+        public bool CrouchTogglePressed { get; private set; }
+        public bool DodgePressed { get; private set; }
+        public bool InteractPressed { get; private set; }
+        public bool PrimaryAttackPressed { get; private set; }
+        public bool GuardHeld { get; private set; }
+        public bool LockTogglePressed { get; private set; }
+        public bool InventoryTogglePressed { get; private set; }
+        public bool EscapePressed { get; private set; }
+        public bool SavePressed => false;
+        public bool LoadPressed => false;
+
+        // Future UI button hooks
+        public void SetMove(Vector2 value) => Move = value;
+        public void SetLook(Vector2 value) => Look = value;
+        public void PressJump() => JumpPressed = true;
+        public void ToggleCrouch() => CrouchTogglePressed = true;
+        public void PressDodge() => DodgePressed = true;
+        public void PressInteract() => InteractPressed = true;
+        public void PressPrimaryAttack() => PrimaryAttackPressed = true;
+        public void SetGuard(bool value) => GuardHeld = value;
+        public void ToggleLock() => LockTogglePressed = true;
+        public void ToggleInventory() => InventoryTogglePressed = true;
+        public void PressEscape() => EscapePressed = true;
+
+        private void LateUpdate()
+        {
+            JumpPressed = false;
+            CrouchTogglePressed = false;
+            DodgePressed = false;
+            InteractPressed = false;
+            PrimaryAttackPressed = false;
+            LockTogglePressed = false;
+            InventoryTogglePressed = false;
+            EscapePressed = false;
+            Look = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Input/PlayerInputReader.cs
+++ b/Assets/Scripts/Core/Input/PlayerInputReader.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Input
+{
+    public class PlayerInputReader : MonoBehaviour
+    {
+        [SerializeField] private MonoBehaviour desktopSourceBehaviour;
+        [SerializeField] private MonoBehaviour mobileSourceBehaviour;
+        [SerializeField] private bool forceDesktopInput = true;
+
+        private IGameInputSource activeSource;
+
+        public Vector2 Move => activeSource != null ? activeSource.Move : Vector2.zero;
+        public Vector2 Look => activeSource != null ? activeSource.Look : Vector2.zero;
+        public bool JumpPressed => activeSource != null && activeSource.JumpPressed;
+        public bool CrouchTogglePressed => activeSource != null && activeSource.CrouchTogglePressed;
+        public bool DodgePressed => activeSource != null && activeSource.DodgePressed;
+        public bool InteractPressed => activeSource != null && activeSource.InteractPressed;
+        public bool PrimaryAttackPressed => activeSource != null && activeSource.PrimaryAttackPressed;
+        public bool GuardHeld => activeSource != null && activeSource.GuardHeld;
+        public bool LockTogglePressed => activeSource != null && activeSource.LockTogglePressed;
+        public bool InventoryTogglePressed => activeSource != null && activeSource.InventoryTogglePressed;
+        public bool EscapePressed => activeSource != null && activeSource.EscapePressed;
+        public bool SavePressed => activeSource != null && activeSource.SavePressed;
+        public bool LoadPressed => activeSource != null && activeSource.LoadPressed;
+
+        private void Awake()
+        {
+            bool useMobile = !forceDesktopInput && Application.isMobilePlatform;
+            var sourceBehaviour = useMobile ? mobileSourceBehaviour : desktopSourceBehaviour;
+            activeSource = sourceBehaviour as IGameInputSource;
+
+            if (activeSource == null)
+            {
+                Debug.LogWarning("PlayerInputReader missing valid input source. Falling back to desktop source if available.");
+                activeSource = desktopSourceBehaviour as IGameInputSource;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Interaction/CraftingStationInteractable.cs
+++ b/Assets/Scripts/Core/Interaction/CraftingStationInteractable.cs
@@ -1,0 +1,23 @@
+using TinyHunter.Core.Player;
+using TinyHunter.UI;
+using UnityEngine;
+
+namespace TinyHunter.Core.Interaction
+{
+    public class CraftingStationInteractable : MonoBehaviour, IInteractable
+    {
+        [SerializeField] private CraftingPanelUI craftingPanel;
+        [SerializeField] private PlayerController playerController;
+
+        public string GetInteractionText() => "Open Crafting";
+
+        public void Interact()
+        {
+            if (craftingPanel != null)
+            {
+                craftingPanel.Toggle();
+                playerController?.SetInteractionState(craftingPanel.IsOpen);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Interaction/IInteractable.cs
+++ b/Assets/Scripts/Core/Interaction/IInteractable.cs
@@ -1,0 +1,8 @@
+namespace TinyHunter.Core.Interaction
+{
+    public interface IInteractable
+    {
+        string GetInteractionText();
+        void Interact();
+    }
+}

--- a/Assets/Scripts/Core/Interaction/PlayerInteractionSystem.cs
+++ b/Assets/Scripts/Core/Interaction/PlayerInteractionSystem.cs
@@ -1,0 +1,85 @@
+using TinyHunter.Core.Input;
+using TinyHunter.Core.Inventory;
+using TinyHunter.Core.Player;
+using TinyHunter.UI;
+using UnityEngine;
+
+namespace TinyHunter.Core.Interaction
+{
+    public class PlayerInteractionSystem : MonoBehaviour
+    {
+        [SerializeField] private PlayerController playerController;
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private InventorySystem inventory;
+        [SerializeField] private float interactRange = 1.6f;
+        [SerializeField] private LayerMask interactionMask;
+        [SerializeField] private InteractionPromptUI promptUI;
+
+        private IInteractable currentInteractable;
+        private WorldPickup currentPickup;
+
+        private void Update()
+        {
+            if (input == null || playerController == null) return;
+            if (!playerController.CanAct())
+            {
+                if (promptUI != null) promptUI.Hide();
+                return;
+            }
+
+            Scan();
+
+            if (input.InteractPressed)
+            {
+                if (currentPickup != null)
+                {
+                    currentPickup.TryCollect(inventory);
+                    return;
+                }
+
+                currentInteractable?.Interact();
+            }
+        }
+
+        private void Scan()
+        {
+            currentInteractable = null;
+            currentPickup = null;
+            if (promptUI != null) promptUI.Hide();
+
+            var hits = Physics.OverlapSphere(transform.position, interactRange, interactionMask);
+            float best = float.MaxValue;
+
+            foreach (var hit in hits)
+            {
+                float distance = Vector3.Distance(transform.position, hit.transform.position);
+                if (distance > best) continue;
+
+                if (hit.TryGetComponent<WorldPickup>(out var pickup))
+                {
+                    best = distance;
+                    currentPickup = pickup;
+                    currentInteractable = null;
+                    continue;
+                }
+
+                var interactable = hit.GetComponent(typeof(IInteractable)) as IInteractable;
+                if (interactable != null)
+                {
+                    best = distance;
+                    currentInteractable = interactable;
+                    currentPickup = null;
+                }
+            }
+
+            if (currentPickup != null)
+            {
+                if (promptUI != null) promptUI.Show($"[E] {currentPickup.DisplayLabel}");
+            }
+            else if (currentInteractable != null)
+            {
+                if (promptUI != null) promptUI.Show($"[E] {currentInteractable.GetInteractionText()}");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Interaction/QuestBoardInteractable.cs
+++ b/Assets/Scripts/Core/Interaction/QuestBoardInteractable.cs
@@ -1,0 +1,25 @@
+using TinyHunter.Core.Quest;
+using TinyHunter.Data.Quests;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Interaction
+{
+    public class QuestBoardInteractable : MonoBehaviour, IInteractable
+    {
+        [SerializeField] private QuestSystem questSystem;
+        [SerializeField] private QuestDefinition defaultQuest;
+        [SerializeField] private DebugChecklistUI checklist;
+
+        public string GetInteractionText() => "Accept Hunt Quest";
+
+        public void Interact()
+        {
+            if (questSystem != null && defaultQuest != null)
+            {
+                questSystem.AcceptQuest(defaultQuest);
+                checklist?.SetQuestAccepted();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Inventory/InventorySystem.cs
+++ b/Assets/Scripts/Core/Inventory/InventorySystem.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Core.Inventory
+{
+    [Serializable]
+    public struct InventoryEntry
+    {
+        public ItemDefinition Item;
+        public int Quantity;
+    }
+
+    public class InventorySystem : MonoBehaviour
+    {
+        [SerializeField] private List<InventoryEntry> entries = new();
+        public event Action<ItemDefinition, int> OnItemChanged;
+
+        public IReadOnlyList<InventoryEntry> Entries => entries;
+
+        public bool HasItem(ItemDefinition item, int amount)
+        {
+            foreach (var entry in entries)
+            {
+                if (entry.Item == item && entry.Quantity >= amount)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void AddItem(ItemDefinition item, int amount)
+        {
+            if (item == null || amount <= 0) return;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (entries[i].Item == item)
+                {
+                    var entry = entries[i];
+                    entry.Quantity += amount;
+                    entries[i] = entry;
+                    OnItemChanged?.Invoke(item, entry.Quantity);
+                    return;
+                }
+            }
+
+            entries.Add(new InventoryEntry { Item = item, Quantity = amount });
+            OnItemChanged?.Invoke(item, amount);
+        }
+
+        public bool RemoveItem(ItemDefinition item, int amount)
+        {
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (entries[i].Item != item) continue;
+                if (entries[i].Quantity < amount) return false;
+
+                var entry = entries[i];
+                entry.Quantity -= amount;
+
+                if (entry.Quantity <= 0)
+                {
+                    entries.RemoveAt(i);
+                    OnItemChanged?.Invoke(item, 0);
+                    return true;
+                }
+
+                entries[i] = entry;
+                OnItemChanged?.Invoke(item, entry.Quantity);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void ClearAll()
+        {
+            entries.Clear();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Inventory/WorldPickup.cs
+++ b/Assets/Scripts/Core/Inventory/WorldPickup.cs
@@ -1,0 +1,50 @@
+using TinyHunter.Core.Player;
+using TinyHunter.Data.Items;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Inventory
+{
+    public class WorldPickup : MonoBehaviour
+    {
+        [SerializeField] private ItemDefinition item;
+        [SerializeField] private int amount = 1;
+        [SerializeField] private bool autoPickupOnTrigger;
+        [SerializeField] private DebugChecklistUI checklist;
+
+        private InventorySystem playerInventory;
+
+        public string DisplayLabel => item == null ? "Pickup" : $"Pick up {item.DisplayName} x{amount}";
+
+        public void Setup(ItemDefinition definition, int quantity)
+        {
+            item = definition;
+            amount = quantity;
+        }
+
+        public bool TryCollect(InventorySystem inventory)
+        {
+            if (item == null || inventory == null) return false;
+            inventory.AddItem(item, amount);
+            checklist?.SetPickedLoot();
+            Destroy(gameObject);
+            return true;
+        }
+
+        private void Start()
+        {
+            var player = FindObjectOfType<PlayerController>();
+            if (player != null)
+            {
+                playerInventory = player.GetComponent<InventorySystem>();
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!autoPickupOnTrigger) return;
+            if (!other.GetComponent<PlayerController>()) return;
+            TryCollect(playerInventory);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Platform/AdaptiveCanvasScaler.cs
+++ b/Assets/Scripts/Core/Platform/AdaptiveCanvasScaler.cs
@@ -1,0 +1,32 @@
+using TinyHunter.Data.Platform;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.Core.Platform
+{
+    [RequireComponent(typeof(CanvasScaler))]
+    public class AdaptiveCanvasScaler : MonoBehaviour
+    {
+        [SerializeField] private GamePlatformSettings settings;
+        [SerializeField] private Vector2 referenceResolution = new(1920f, 1080f);
+        [SerializeField] private bool treatEditorAsPc = true;
+
+        private void Awake()
+        {
+            var scaler = GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = referenceResolution;
+
+            if (settings == null)
+            {
+                scaler.matchWidthOrHeight = 0.5f;
+                return;
+            }
+
+            bool isMobile = Application.isMobilePlatform && !(Application.isEditor && treatEditorAsPc);
+            scaler.matchWidthOrHeight = isMobile
+                ? settings.Mobile.CanvasMatchWidthOrHeight
+                : settings.Pc.CanvasMatchWidthOrHeight;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Platform/PlatformBootstrap.cs
+++ b/Assets/Scripts/Core/Platform/PlatformBootstrap.cs
@@ -1,0 +1,26 @@
+using TinyHunter.Data.Platform;
+using UnityEngine;
+
+namespace TinyHunter.Core.Platform
+{
+    public class PlatformBootstrap : MonoBehaviour
+    {
+        [SerializeField] private GamePlatformSettings settings;
+        [SerializeField] private bool treatEditorAsPc = true;
+
+        private void Awake()
+        {
+            if (settings == null) return;
+
+            bool isMobile = Application.isMobilePlatform && !(Application.isEditor && treatEditorAsPc);
+            var selected = isMobile ? settings.Mobile : settings.Pc;
+
+            Application.targetFrameRate = selected.TargetFrameRate;
+
+            if (selected.QualityLevel >= 0 && selected.QualityLevel < QualitySettings.names.Length)
+            {
+                QualitySettings.SetQualityLevel(selected.QualityLevel, true);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Player/PlayerAnimationBridge.cs
+++ b/Assets/Scripts/Core/Player/PlayerAnimationBridge.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace TinyHunter.Core.Player
+{
+    public class PlayerAnimationBridge : MonoBehaviour
+    {
+        [SerializeField] private Animator animator;
+
+        private static readonly int LightAttackTrigger = Animator.StringToHash("LightAttack");
+        private static readonly int HeavyAttackTrigger = Animator.StringToHash("HeavyAttack");
+        private static readonly int DodgeTrigger = Animator.StringToHash("Dodge");
+        private static readonly int HitTrigger = Animator.StringToHash("Hit");
+        private static readonly int DeathTrigger = Animator.StringToHash("Death");
+
+        public void TriggerLightAttack() => SetTrigger(LightAttackTrigger);
+        public void TriggerHeavyAttack() => SetTrigger(HeavyAttackTrigger);
+        public void TriggerDodge() => SetTrigger(DodgeTrigger);
+        public void TriggerHit() => SetTrigger(HitTrigger);
+        public void TriggerDeath() => SetTrigger(DeathTrigger);
+
+        private void SetTrigger(int triggerHash)
+        {
+            if (animator == null) return;
+            animator.SetTrigger(triggerHash);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Player/PlayerController.cs
+++ b/Assets/Scripts/Core/Player/PlayerController.cs
@@ -1,0 +1,162 @@
+using TinyHunter.Core.Combat;
+using TinyHunter.Core.Input;
+using UnityEngine;
+
+namespace TinyHunter.Core.Player
+{
+    [RequireComponent(typeof(CharacterController))]
+    public class PlayerController : MonoBehaviour
+    {
+        public enum PlayerState { Movement, Attacking, Dodging, Interacting, Dead }
+
+        [SerializeField] private PlayerStats stats;
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private TargetLockSystem lockSystem;
+        [SerializeField] private Transform cameraPivot;
+        [SerializeField] private float gravity = -20f;
+        [SerializeField] private float jumpHeight = 0.8f;
+        [SerializeField] private float dodgeDistance = 1.2f;
+        [SerializeField] private float dodgeStaminaCost = 20f;
+        [SerializeField] private float dodgeDuration = 0.22f;
+        [SerializeField] private float crouchSpeedMultiplier = 0.65f;
+        [SerializeField] private PlayerAnimationBridge animationBridge;
+
+        public bool IsCrouching { get; private set; }
+        public PlayerState CurrentState { get; private set; } = PlayerState.Movement;
+
+        private CharacterController controller;
+        private Vector3 velocity;
+        private float stateTimer;
+
+        private void Awake() => controller = GetComponent<CharacterController>();
+
+        private void Update()
+        {
+            if (stats == null || input == null) return;
+
+            if (stats.IsDead)
+            {
+                CurrentState = PlayerState.Dead;
+                return;
+            }
+
+            if (input.LockTogglePressed) lockSystem?.ToggleLock();
+            if (input.CrouchTogglePressed) ToggleCrouch();
+
+            UpdateStateMachine();
+            stats.RegenerateStamina(16f);
+        }
+
+        private void UpdateStateMachine()
+        {
+            if (CurrentState == PlayerState.Dodging)
+            {
+                stateTimer -= Time.deltaTime;
+                if (stateTimer <= 0f) CurrentState = PlayerState.Movement;
+                ApplyGravity();
+                return;
+            }
+
+            if (CurrentState == PlayerState.Interacting || CurrentState == PlayerState.Attacking) return;
+
+            if (input.DodgePressed && stats.SpendStamina(dodgeStaminaCost))
+            {
+                StartDodge();
+                return;
+            }
+
+            Move();
+            HandleJump();
+            ApplyGravity();
+        }
+
+        private void Move()
+        {
+            Vector2 moveInput = input.Move;
+            Vector3 inputDir = new(moveInput.x, 0f, moveInput.y);
+
+            Vector3 forward = cameraPivot.forward;
+            Vector3 right = cameraPivot.right;
+            forward.y = 0f;
+            right.y = 0f;
+            Vector3 move = (forward.normalized * inputDir.z + right.normalized * inputDir.x).normalized;
+
+            if (lockSystem != null && lockSystem.CurrentTarget != null)
+            {
+                Vector3 toTarget = lockSystem.CurrentTarget.position - transform.position;
+                toTarget.y = 0f;
+                if (toTarget.sqrMagnitude > 0.01f)
+                {
+                    transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(toTarget), Time.deltaTime * 10f);
+                }
+            }
+            else if (move.sqrMagnitude > 0.01f)
+            {
+                transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(move), Time.deltaTime * 10f);
+            }
+
+            float speed = stats.MoveSpeed * (IsCrouching ? crouchSpeedMultiplier : 1f);
+            controller.Move(move * speed * Time.deltaTime);
+        }
+
+        private void HandleJump()
+        {
+            if (input.JumpPressed && controller.isGrounded)
+            {
+                velocity.y = Mathf.Sqrt(jumpHeight * -2f * gravity);
+            }
+        }
+
+        private void ApplyGravity()
+        {
+            if (controller.isGrounded && velocity.y < 0f)
+            {
+                velocity.y = -1f;
+            }
+            else
+            {
+                velocity.y += gravity * Time.deltaTime;
+            }
+
+            controller.Move(velocity * Time.deltaTime);
+        }
+
+        private void StartDodge()
+        {
+            CurrentState = PlayerState.Dodging;
+            stateTimer = dodgeDuration;
+            animationBridge?.TriggerDodge();
+            Vector3 dodgeDir = transform.forward * dodgeDistance * stats.DodgeEfficiency;
+            controller.Move(dodgeDir);
+        }
+
+        private void ToggleCrouch()
+        {
+            IsCrouching = !IsCrouching;
+            controller.height = IsCrouching ? 1f : 1.8f;
+            controller.center = IsCrouching ? new Vector3(0f, 0.5f, 0f) : new Vector3(0f, 0.9f, 0f);
+        }
+
+        public bool CanAct() => CurrentState == PlayerState.Movement;
+
+        public void SetInteractionState(bool interacting)
+        {
+            if (stats != null && stats.IsDead) return;
+            CurrentState = interacting ? PlayerState.Interacting : PlayerState.Movement;
+        }
+
+        public void SetAttackState(float duration)
+        {
+            if (!CanAct()) return;
+            CurrentState = PlayerState.Attacking;
+            stateTimer = duration;
+            StartCoroutine(EndAttackState());
+        }
+
+        private System.Collections.IEnumerator EndAttackState()
+        {
+            yield return new WaitForSeconds(stateTimer);
+            if (CurrentState == PlayerState.Attacking) CurrentState = PlayerState.Movement;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Quest/QuestSystem.cs
+++ b/Assets/Scripts/Core/Quest/QuestSystem.cs
@@ -1,0 +1,49 @@
+using System;
+using TinyHunter.Core.Inventory;
+using TinyHunter.Data.Quests;
+using UnityEngine;
+
+namespace TinyHunter.Core.Quest
+{
+    public class QuestSystem : MonoBehaviour
+    {
+        [SerializeField] private InventorySystem inventory;
+
+        public QuestDefinition ActiveQuest { get; private set; }
+        public int CurrentProgress { get; private set; }
+        public bool IsQuestComplete { get; private set; }
+
+        public event Action<QuestDefinition> OnQuestAccepted;
+        public event Action<QuestDefinition, int, int> OnQuestProgressChanged;
+        public event Action<QuestDefinition> OnQuestCompleted;
+
+        public void AcceptQuest(QuestDefinition quest)
+        {
+            ActiveQuest = quest;
+            CurrentProgress = 0;
+            IsQuestComplete = false;
+            OnQuestAccepted?.Invoke(ActiveQuest);
+            OnQuestProgressChanged?.Invoke(ActiveQuest, CurrentProgress, ActiveQuest.TargetCount);
+        }
+
+        public void RegisterTargetDefeated(string monsterId)
+        {
+            if (ActiveQuest == null || ActiveQuest.TargetMonster == null || IsQuestComplete) return;
+            if (ActiveQuest.TargetMonster.MonsterId != monsterId) return;
+
+            CurrentProgress++;
+            OnQuestProgressChanged?.Invoke(ActiveQuest, CurrentProgress, ActiveQuest.TargetCount);
+
+            if (CurrentProgress < ActiveQuest.TargetCount) return;
+
+            IsQuestComplete = true;
+            if (ActiveQuest.RewardItem != null && ActiveQuest.RewardAmount > 0 && inventory != null)
+            {
+                inventory.AddItem(ActiveQuest.RewardItem, ActiveQuest.RewardAmount);
+            }
+
+            OnQuestCompleted?.Invoke(ActiveQuest);
+            Debug.Log($"Quest complete: {ActiveQuest.DisplayName}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/Respawn/PlayerDeathHandler.cs
+++ b/Assets/Scripts/Core/Respawn/PlayerDeathHandler.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using TinyHunter.Core.Combat;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.Core.Respawn
+{
+    public class PlayerDeathHandler : MonoBehaviour
+    {
+        [SerializeField] private PlayerStats stats;
+        [SerializeField] private RespawnController respawnController;
+        [SerializeField] private PauseMenuUI deathScreen;
+        [SerializeField] private float respawnDelay = 2f;
+
+        private bool handled;
+
+        private void Update()
+        {
+            if (stats == null || handled || !stats.IsDead) return;
+            handled = true;
+            if (deathScreen != null)
+            {
+                deathScreen.ShowDeathState();
+            }
+
+            StartCoroutine(RespawnRoutine());
+        }
+
+        private IEnumerator RespawnRoutine()
+        {
+            yield return new WaitForSeconds(respawnDelay);
+            respawnController.ReturnToHubOnDeath();
+            handled = false;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Respawn/RespawnController.cs
+++ b/Assets/Scripts/Core/Respawn/RespawnController.cs
@@ -1,0 +1,28 @@
+using TinyHunter.Core.Combat;
+using TinyHunter.Core.Flow;
+using UnityEngine;
+
+namespace TinyHunter.Core.Respawn
+{
+    public class RespawnController : MonoBehaviour
+    {
+        [SerializeField] private Transform respawnPoint;
+        [SerializeField] private PlayerStats playerStats;
+
+        public void RespawnPlayer(GameObject player)
+        {
+            if (respawnPoint != null)
+            {
+                player.transform.position = respawnPoint.position;
+                player.transform.rotation = respawnPoint.rotation;
+            }
+
+            playerStats?.RestoreToFull();
+        }
+
+        public void ReturnToHubOnDeath()
+        {
+            SceneFlowController.Instance.ReturnToHub();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Save/SaveData.cs
+++ b/Assets/Scripts/Core/Save/SaveData.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using TinyHunter.Core.Character;
+
+namespace TinyHunter.Core.Save
+{
+    [Serializable]
+    public class SaveInventoryEntry
+    {
+        public string itemId;
+        public int quantity;
+    }
+
+    [Serializable]
+    public class SaveData
+    {
+        public List<SaveInventoryEntry> inventory = new();
+        public string equippedWeaponId;
+        public string equippedHeadArmorId;
+        public string activeQuestId;
+
+        // Future-compatible creator/profile data (dormant until creator flow is activated).
+        public PlayerProfileData profile = new PlayerProfileData();
+    }
+}

--- a/Assets/Scripts/Core/Save/SaveSystem.cs
+++ b/Assets/Scripts/Core/Save/SaveSystem.cs
@@ -1,0 +1,133 @@
+using System.IO;
+using TinyHunter.Core.Character;
+using TinyHunter.Core.Equipment;
+using TinyHunter.Core.Inventory;
+using TinyHunter.Core.Quest;
+using TinyHunter.Data.Items;
+using TinyHunter.Data.Quests;
+using UnityEngine;
+
+namespace TinyHunter.Core.Save
+{
+    public class SaveSystem : MonoBehaviour
+    {
+        public static SaveSystem Instance { get; private set; }
+
+        [SerializeField] private ItemDatabase itemDatabase;
+        [SerializeField] private QuestDefinition[] knownQuests;
+
+        [Header("Future Character Creator Compatibility")]
+        [SerializeField] private CharacterAppearanceData defaultAppearance = CharacterAppearanceData.Default();
+
+        public static string SavePath => Path.Combine(Application.persistentDataPath, "tinyhunter_mvp_save.json");
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        public bool HasSave() => File.Exists(SavePath);
+
+        public void SaveGame()
+        {
+            var inventory = FindObjectOfType<InventorySystem>();
+            var equipment = FindObjectOfType<EquipmentSystem>();
+            var questSystem = FindObjectOfType<QuestSystem>();
+            var customizer = FindObjectOfType<CharacterCustomizer>();
+            if (inventory == null || equipment == null || questSystem == null) return;
+
+            SaveData data = new();
+            foreach (var entry in inventory.Entries)
+            {
+                if (entry.Item == null) continue;
+                data.inventory.Add(new SaveInventoryEntry { itemId = entry.Item.ItemId, quantity = entry.Quantity });
+            }
+
+            data.equippedWeaponId = equipment.EquippedWeapon != null ? equipment.EquippedWeapon.ItemId : null;
+            data.equippedHeadArmorId = equipment.EquippedHead != null ? equipment.EquippedHead.ItemId : null;
+            data.activeQuestId = questSystem.ActiveQuest != null ? questSystem.ActiveQuest.QuestId : null;
+
+            if (data.profile == null) data.profile = new PlayerProfileData();
+            if (data.profile.Appearance == null)
+            {
+                data.profile.Appearance = defaultAppearance != null ? defaultAppearance : CharacterAppearanceData.Default();
+            }
+
+            // Future hook: when creator UI is active, source appearance from profile manager/customizer.
+            if (customizer == null)
+            {
+                // Keep current default-compatible profile data in save for forward compatibility.
+                data.profile.Appearance = data.profile.Appearance ?? CharacterAppearanceData.Default();
+            }
+
+            File.WriteAllText(SavePath, JsonUtility.ToJson(data, true));
+            Debug.Log($"Saved game: {SavePath}");
+        }
+
+        public void LoadGame()
+        {
+            if (!HasSave()) return;
+            var inventory = FindObjectOfType<InventorySystem>();
+            var equipment = FindObjectOfType<EquipmentSystem>();
+            var questSystem = FindObjectOfType<QuestSystem>();
+            var customizer = FindObjectOfType<CharacterCustomizer>();
+            if (inventory == null || equipment == null || questSystem == null || itemDatabase == null) return;
+
+            var json = File.ReadAllText(SavePath);
+            var data = JsonUtility.FromJson<SaveData>(json);
+            if (data == null) return;
+
+            inventory.ClearAll();
+            foreach (var saved in data.inventory)
+            {
+                var item = itemDatabase.FindById(saved.itemId);
+                if (item != null) inventory.AddItem(item, saved.quantity);
+            }
+
+            if (!string.IsNullOrEmpty(data.equippedWeaponId))
+            {
+                var weapon = itemDatabase.FindById<WeaponDefinition>(data.equippedWeaponId);
+                if (weapon != null) equipment.EquipWeapon(weapon);
+            }
+
+            if (!string.IsNullOrEmpty(data.equippedHeadArmorId))
+            {
+                var armor = itemDatabase.FindById<ArmorDefinition>(data.equippedHeadArmorId);
+                if (armor != null) equipment.EquipArmor(armor);
+            }
+
+            if (!string.IsNullOrEmpty(data.activeQuestId))
+            {
+                foreach (var q in knownQuests)
+                {
+                    if (q != null && q.QuestId == data.activeQuestId)
+                    {
+                        questSystem.AcceptQuest(q);
+                        break;
+                    }
+                }
+            }
+
+            if (data.profile == null) data.profile = new PlayerProfileData();
+            if (data.profile.Appearance == null)
+            {
+                data.profile.Appearance = defaultAppearance != null ? defaultAppearance : CharacterAppearanceData.Default();
+            }
+
+            // Dormant apply hook: safe no-op unless CharacterCustomizer exists on active player prefab.
+            if (customizer != null)
+            {
+                customizer.ApplyAppearance(data.profile.Appearance);
+            }
+
+            Debug.Log("Loaded game save.");
+        }
+    }
+}

--- a/Assets/Scripts/Data/Combat/CombatTypes.cs
+++ b/Assets/Scripts/Data/Combat/CombatTypes.cs
@@ -1,0 +1,20 @@
+namespace TinyHunter.Data.Combat
+{
+    public enum DamageType
+    {
+        Slash,
+        Pierce,
+        Blunt,
+        Poison,
+        Acid,
+        Water,
+        Impact
+    }
+
+    public enum AttackWeight
+    {
+        Light,
+        Heavy,
+        Charged
+    }
+}

--- a/Assets/Scripts/Data/Crafting/CraftingRecipeDefinition.cs
+++ b/Assets/Scripts/Data/Crafting/CraftingRecipeDefinition.cs
@@ -1,0 +1,25 @@
+using System;
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Data.Crafting
+{
+    [Serializable]
+    public struct MaterialCost
+    {
+        public ItemDefinition Item;
+        public int Amount;
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Crafting Recipe")]
+    public class CraftingRecipeDefinition : ScriptableObject
+    {
+        public string RecipeId;
+        public string DisplayName;
+        public ItemCategory OutputCategory;
+        public ItemDefinition OutputItem;
+        public int OutputAmount = 1;
+        public string UnlockCondition;
+        public MaterialCost[] Costs;
+    }
+}

--- a/Assets/Scripts/Data/Items/ArmorDefinition.cs
+++ b/Assets/Scripts/Data/Items/ArmorDefinition.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace TinyHunter.Data.Items
+{
+    public enum ArmorSlot { Head, Chest, Arms, Waist, Legs }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Armor")]
+    public class ArmorDefinition : ScriptableObject
+    {
+        public string ArmorId;
+        public string DisplayName;
+        public ArmorSlot Slot;
+        public int Defense;
+        public float PoisonResistance;
+        public float AcidResistance;
+        public float WaterResistance;
+        public float ImpactResistance;
+        public float StaminaModifier;
+        public float DodgeEfficiencyModifier;
+    }
+}

--- a/Assets/Scripts/Data/Items/ItemDatabase.cs
+++ b/Assets/Scripts/Data/Items/ItemDatabase.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TinyHunter.Data.Items
+{
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Item Database")]
+    public class ItemDatabase : ScriptableObject
+    {
+        public ItemDefinition[] Items;
+
+        public ItemDefinition FindById(string id)
+        {
+            foreach (var item in Items)
+            {
+                if (item != null && item.ItemId == id) return item;
+            }
+
+            return null;
+        }
+
+        public T FindById<T>(string id) where T : ItemDefinition
+        {
+            return FindById(id) as T;
+        }
+    }
+}

--- a/Assets/Scripts/Data/Items/ItemDefinition.cs
+++ b/Assets/Scripts/Data/Items/ItemDefinition.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace TinyHunter.Data.Items
+{
+    public enum ItemCategory
+    {
+        Material,
+        Consumable,
+        Weapon,
+        Armor,
+        Tool,
+        Quest
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Item")]
+    public class ItemDefinition : ScriptableObject
+    {
+        [Header("Identity")]
+        public string ItemId;
+        public string DisplayName;
+        [TextArea] public string Description;
+        public ItemCategory Category;
+
+        [Header("Economy")]
+        public int SellValue;
+        public bool Stackable = true;
+        public int MaxStack = 99;
+
+        [Header("Presentation")]
+        public Sprite Icon;
+        public GameObject WorldPickupPrefab;
+    }
+}

--- a/Assets/Scripts/Data/Items/WeaponDefinition.cs
+++ b/Assets/Scripts/Data/Items/WeaponDefinition.cs
@@ -1,0 +1,29 @@
+using TinyHunter.Data.Combat;
+using UnityEngine;
+
+namespace TinyHunter.Data.Items
+{
+    public enum WeaponClass
+    {
+        NeedleSpear,
+        PinBlade,
+        ButtonHammer,
+        StapleBow,
+        RazorShardAxe
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Weapon")]
+    public class WeaponDefinition : ScriptableObject
+    {
+        public string WeaponId;
+        public string DisplayName;
+        public WeaponClass WeaponClass;
+        public DamageType DamageType;
+        public float AttackPower = 10f;
+        public float StaminaCostLight = 8f;
+        public float StaminaCostHeavy = 18f;
+        public float Reach = 1.2f;
+        public bool CanBlock;
+        public float GuardDamageReduction = 0.5f;
+    }
+}

--- a/Assets/Scripts/Data/Monsters/LootTableDefinition.cs
+++ b/Assets/Scripts/Data/Monsters/LootTableDefinition.cs
@@ -1,0 +1,30 @@
+using System;
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Data.Monsters
+{
+    public enum LootRarity
+    {
+        Common,
+        Uncommon,
+        Rare,
+        VeryRare
+    }
+
+    [Serializable]
+    public struct LootEntry
+    {
+        public ItemDefinition Item;
+        public LootRarity Rarity;
+        [Range(0f, 1f)] public float DropChance;
+        public int MinAmount;
+        public int MaxAmount;
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Loot Table")]
+    public class LootTableDefinition : ScriptableObject
+    {
+        public LootEntry[] Entries;
+    }
+}

--- a/Assets/Scripts/Data/Monsters/MonsterDefinition.cs
+++ b/Assets/Scripts/Data/Monsters/MonsterDefinition.cs
@@ -1,0 +1,32 @@
+using TinyHunter.Data.Combat;
+using UnityEngine;
+
+namespace TinyHunter.Data.Monsters
+{
+    public enum MonsterSizeCategory { Small, Medium, Large, Flagship }
+    public enum AggressionLevel { Passive, Defensive, Aggressive, Frenzied }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Monster")]
+    public class MonsterDefinition : ScriptableObject
+    {
+        [Header("Identity")]
+        public string MonsterId;
+        public string DisplayName;
+        [TextArea] public string EcologicalRole;
+        [TextArea] public string Territory;
+
+        [Header("Combat")]
+        public MonsterSizeCategory SizeCategory;
+        public AggressionLevel Aggression;
+        public float MaxHealth = 400f;
+        public float BaseAttack = 15f;
+        public float MoveSpeed = 2f;
+        public DamageType Weakness;
+
+        [Header("Anatomy")]
+        public MonsterPartDefinition[] BreakableParts;
+
+        [Header("Rewards")]
+        public LootTableDefinition LootTable;
+    }
+}

--- a/Assets/Scripts/Data/Monsters/MonsterPartDefinition.cs
+++ b/Assets/Scripts/Data/Monsters/MonsterPartDefinition.cs
@@ -1,0 +1,21 @@
+using TinyHunter.Data.Items;
+using UnityEngine;
+
+namespace TinyHunter.Data.Monsters
+{
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Monster Part")]
+    public class MonsterPartDefinition : ScriptableObject
+    {
+        public string PartId;
+        public string DisplayName;
+        public float MaxDurability = 100f;
+        public float BreakDamageMultiplier = 1f;
+
+        [Header("Combat Impact")]
+        public string GameplayEffectOnBreak;
+
+        [Header("Rewards")]
+        public ItemDefinition GuaranteedDrop;
+        public int GuaranteedDropAmount = 1;
+    }
+}

--- a/Assets/Scripts/Data/Platform/GamePlatformSettings.cs
+++ b/Assets/Scripts/Data/Platform/GamePlatformSettings.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+
+namespace TinyHunter.Data.Platform
+{
+    [Serializable]
+    public class PlatformTuning
+    {
+        public int TargetFrameRate = 60;
+        public int QualityLevel = 2;
+        [Range(0f, 1f)] public float CanvasMatchWidthOrHeight = 0.5f;
+        public int MaxRecommendedEnemies = 3;
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Platform Settings")]
+    public class GamePlatformSettings : ScriptableObject
+    {
+        public PlatformTuning Pc = new();
+        public PlatformTuning Mobile = new()
+        {
+            TargetFrameRate = 30,
+            QualityLevel = 1,
+            CanvasMatchWidthOrHeight = 0.65f,
+            MaxRecommendedEnemies = 2
+        };
+    }
+}

--- a/Assets/Scripts/Data/Quests/QuestDefinition.cs
+++ b/Assets/Scripts/Data/Quests/QuestDefinition.cs
@@ -1,0 +1,29 @@
+using TinyHunter.Data.Items;
+using TinyHunter.Data.Monsters;
+using UnityEngine;
+
+namespace TinyHunter.Data.Quests
+{
+    public enum QuestType
+    {
+        SlayTarget,
+        CaptureTarget,
+        GatherMaterials,
+        EliminateInfestation,
+        InvestigateNest
+    }
+
+    [CreateAssetMenu(menuName = "TinyHunter/Data/Quest")]
+    public class QuestDefinition : ScriptableObject
+    {
+        public string QuestId;
+        public string DisplayName;
+        [TextArea] public string Objective;
+        public QuestType QuestType;
+        public MonsterDefinition TargetMonster;
+        public int TargetCount = 1;
+        public float TimeLimitSeconds = 1200f;
+        public ItemDefinition RewardItem;
+        public int RewardAmount;
+    }
+}

--- a/Assets/Scripts/MVP/Enemies/AntSoldierAI.cs
+++ b/Assets/Scripts/MVP/Enemies/AntSoldierAI.cs
@@ -1,0 +1,140 @@
+using TinyHunter.Core.Player;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace TinyHunter.MVP.Enemies
+{
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class AntSoldierAI : MonoBehaviour
+    {
+        private enum State { Idle, Patrol, Chase, Attack, Recover, ReturnToNest }
+
+        [SerializeField] private Transform nestPoint;
+        [SerializeField] private Transform[] patrolPoints;
+        [SerializeField] private float detectionRange = 7f;
+        [SerializeField] private float attackRange = 1f;
+        [SerializeField] private float attackDamage = 12f;
+        [SerializeField] private float attackCooldown = 1.2f;
+        [SerializeField] private float idleDuration = 1.5f;
+        [SerializeField] private float chaseTimeout = 5f;
+
+        private PlayerController player;
+        private NavMeshAgent agent;
+        private State currentState;
+        private int patrolIndex;
+        private float stateTimer;
+        private float timeSinceSeenPlayer;
+
+        private void Awake() => agent = GetComponent<NavMeshAgent>();
+
+        private void Start()
+        {
+            player = FindObjectOfType<PlayerController>();
+            currentState = State.Idle;
+            stateTimer = idleDuration;
+        }
+
+        private void Update()
+        {
+            if (player == null) return;
+
+            float distanceToPlayer = Vector3.Distance(transform.position, player.transform.position);
+            bool seesPlayer = distanceToPlayer <= detectionRange;
+            if (seesPlayer) timeSinceSeenPlayer = 0f;
+            else timeSinceSeenPlayer += Time.deltaTime;
+
+            switch (currentState)
+            {
+                case State.Idle: UpdateIdle(seesPlayer); break;
+                case State.Patrol: UpdatePatrol(seesPlayer); break;
+                case State.Chase: UpdateChase(distanceToPlayer); break;
+                case State.Attack: UpdateAttack(distanceToPlayer); break;
+                case State.Recover: UpdateRecover(); break;
+                case State.ReturnToNest: UpdateReturnToNest(); break;
+            }
+        }
+
+        private void UpdateIdle(bool seesPlayer)
+        {
+            if (seesPlayer) { currentState = State.Chase; return; }
+            stateTimer -= Time.deltaTime;
+            if (stateTimer <= 0f)
+            {
+                currentState = patrolPoints.Length > 0 ? State.Patrol : State.ReturnToNest;
+            }
+        }
+
+        private void UpdatePatrol(bool seesPlayer)
+        {
+            if (seesPlayer) { currentState = State.Chase; return; }
+            if (patrolPoints.Length == 0) { currentState = State.ReturnToNest; return; }
+
+            agent.SetDestination(patrolPoints[patrolIndex].position);
+            if (!agent.pathPending && agent.remainingDistance <= 0.3f)
+            {
+                patrolIndex = (patrolIndex + 1) % patrolPoints.Length;
+                currentState = State.Idle;
+                stateTimer = idleDuration;
+            }
+        }
+
+        private void UpdateChase(float distanceToPlayer)
+        {
+            agent.SetDestination(player.transform.position);
+            if (distanceToPlayer <= attackRange)
+            {
+                currentState = State.Attack;
+                stateTimer = attackCooldown;
+                return;
+            }
+
+            if (timeSinceSeenPlayer >= chaseTimeout)
+            {
+                currentState = State.ReturnToNest;
+            }
+        }
+
+        private void UpdateAttack(float distanceToPlayer)
+        {
+            stateTimer -= Time.deltaTime;
+            if (distanceToPlayer > attackRange)
+            {
+                currentState = State.Chase;
+                return;
+            }
+
+            if (stateTimer > 0f) return;
+
+            var stats = player.GetComponent<TinyHunter.Core.Combat.PlayerStats>();
+            if (stats != null) stats.ApplyDamage(attackDamage);
+            currentState = State.Recover;
+            stateTimer = 0.6f;
+        }
+
+        private void UpdateRecover()
+        {
+            stateTimer -= Time.deltaTime;
+            if (stateTimer <= 0f)
+            {
+                currentState = State.Chase;
+            }
+        }
+
+        private void UpdateReturnToNest()
+        {
+            if (nestPoint == null)
+            {
+                currentState = State.Idle;
+                stateTimer = idleDuration;
+                return;
+            }
+
+            agent.SetDestination(nestPoint.position);
+            if (!agent.pathPending && agent.remainingDistance <= 0.5f)
+            {
+                currentState = State.Idle;
+                stateTimer = idleDuration;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/MVP/Enemies/SpiderAmbushAI.cs
+++ b/Assets/Scripts/MVP/Enemies/SpiderAmbushAI.cs
@@ -1,0 +1,108 @@
+using TinyHunter.Core.Combat;
+using TinyHunter.Core.Player;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace TinyHunter.MVP.Enemies
+{
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class SpiderAmbushAI : MonoBehaviour
+    {
+        private enum State { Hidden, AmbushReady, Lunge, Recover, RetreatToWeb }
+
+        [SerializeField] private Transform webRetreatPoint;
+        [SerializeField] private float ambushTriggerDistance = 5f;
+        [SerializeField] private float lungeDistance = 2.2f;
+        [SerializeField] private float lungeDamage = 20f;
+        [SerializeField] private float venomDamagePerTick = 3f;
+        [SerializeField] private int venomTicks = 3;
+
+        private PlayerController player;
+        private PlayerStats playerStats;
+        private NavMeshAgent agent;
+        private State currentState;
+        private float stateTimer;
+
+        private void Awake() => agent = GetComponent<NavMeshAgent>();
+
+        private void Start()
+        {
+            player = FindObjectOfType<PlayerController>();
+            if (player != null) playerStats = player.GetComponent<PlayerStats>();
+            currentState = State.Hidden;
+        }
+
+        private void Update()
+        {
+            if (player == null || playerStats == null) return;
+
+            float distance = Vector3.Distance(transform.position, player.transform.position);
+            switch (currentState)
+            {
+                case State.Hidden: UpdateHidden(distance); break;
+                case State.AmbushReady: UpdateAmbushReady(distance); break;
+                case State.Lunge: UpdateLunge(distance); break;
+                case State.Recover: UpdateRecover(); break;
+                case State.RetreatToWeb: UpdateRetreat(); break;
+            }
+        }
+
+        private void UpdateHidden(float distance)
+        {
+            if (distance <= ambushTriggerDistance)
+            {
+                currentState = State.AmbushReady;
+                stateTimer = 0.5f;
+            }
+        }
+
+        private void UpdateAmbushReady(float distance)
+        {
+            transform.LookAt(new Vector3(player.transform.position.x, transform.position.y, player.transform.position.z));
+            stateTimer -= Time.deltaTime;
+            if (stateTimer <= 0f && distance <= ambushTriggerDistance)
+            {
+                currentState = State.Lunge;
+            }
+        }
+
+        private void UpdateLunge(float distance)
+        {
+            agent.SetDestination(player.transform.position);
+            if (distance > lungeDistance) return;
+
+            playerStats.ApplyDamage(lungeDamage);
+            for (int i = 0; i < venomTicks; i++)
+            {
+                playerStats.ApplyDamage(venomDamagePerTick);
+            }
+
+            currentState = State.Recover;
+            stateTimer = 1.2f;
+        }
+
+        private void UpdateRecover()
+        {
+            stateTimer -= Time.deltaTime;
+            if (stateTimer <= 0f)
+            {
+                currentState = State.RetreatToWeb;
+            }
+        }
+
+        private void UpdateRetreat()
+        {
+            if (webRetreatPoint == null)
+            {
+                currentState = State.Hidden;
+                return;
+            }
+
+            agent.SetDestination(webRetreatPoint.position);
+            if (!agent.pathPending && agent.remainingDistance <= 0.4f)
+            {
+                currentState = State.Hidden;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/CraftingPanelUI.cs
+++ b/Assets/Scripts/UI/CraftingPanelUI.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using TinyHunter.Core.Crafting;
+using TinyHunter.Core.Equipment;
+using TinyHunter.Core.Input;
+using TinyHunter.Data.Crafting;
+using TinyHunter.Data.Items;
+using TinyHunter.UI.Panels;
+using UnityEngine;
+
+namespace TinyHunter.UI
+{
+    public class CraftingPanelUI : MonoBehaviour
+    {
+        [SerializeField] private CraftingSystem craftingSystem;
+        [SerializeField] private EquipmentSystem equipmentSystem;
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private DebugChecklistUI checklist;
+        [SerializeField] private GameObject panelRoot;
+        [SerializeField] private RecipeEntryUI recipeEntryPrefab;
+        [SerializeField] private Transform recipeContainer;
+        [SerializeField] private CraftingRecipeDefinition[] recipes;
+
+        private readonly List<RecipeEntryUI> entries = new();
+
+        private void Start()
+        {
+            BuildEntries();
+            if (panelRoot != null) panelRoot.SetActive(false);
+            if (craftingSystem != null) craftingSystem.OnCrafted += HandleCrafted;
+        }
+
+        private void Update()
+        {
+            if (panelRoot == null || !panelRoot.activeSelf || input == null) return;
+            if (input.InteractPressed)
+            {
+                foreach (var entry in entries)
+                {
+                    if (entry.TryCraftViaHotkey())
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        public bool IsOpen => panelRoot != null && panelRoot.activeSelf;
+
+        public void Close()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+        }
+
+        public void Toggle()
+        {
+            if (panelRoot == null) return;
+            panelRoot.SetActive(!panelRoot.activeSelf);
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            foreach (var entry in entries)
+            {
+                entry.Refresh();
+            }
+        }
+
+        private void BuildEntries()
+        {
+            foreach (var recipe in recipes)
+            {
+                if (recipe == null) continue;
+                var entry = Instantiate(recipeEntryPrefab, recipeContainer);
+                entry.Bind(recipe, craftingSystem);
+                entries.Add(entry);
+            }
+        }
+
+        private void HandleCrafted(CraftingRecipeDefinition recipe)
+        {
+            checklist?.SetCraftedItem();
+            if (recipe.OutputItem is WeaponDefinition weapon)
+            {
+                equipmentSystem?.EquipWeapon(weapon);
+                checklist?.SetEquippedItem();
+            }
+            else if (recipe.OutputItem is ArmorDefinition armor)
+            {
+                equipmentSystem?.EquipArmor(armor);
+                checklist?.SetEquippedItem();
+            }
+
+            Refresh();
+        }
+    }
+}

--- a/Assets/Scripts/UI/InteractionPromptUI.cs
+++ b/Assets/Scripts/UI/InteractionPromptUI.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI
+{
+    public class InteractionPromptUI : MonoBehaviour
+    {
+        [SerializeField] private GameObject root;
+        [SerializeField] private Text promptText;
+
+        public void Show(string text)
+        {
+            if (root != null) root.SetActive(true);
+            if (promptText != null) promptText.text = text;
+        }
+
+        public void Hide()
+        {
+            if (root != null) root.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Panels/DebugChecklistUI.cs
+++ b/Assets/Scripts/UI/Panels/DebugChecklistUI.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI.Panels
+{
+    public class DebugChecklistUI : MonoBehaviour
+    {
+        [SerializeField] private Text checklistText;
+        [SerializeField] private bool questAccepted;
+        [SerializeField] private bool enteredHunt;
+        [SerializeField] private bool killedTarget;
+        [SerializeField] private bool pickedLoot;
+        [SerializeField] private bool returnedHub;
+        [SerializeField] private bool craftedItem;
+        [SerializeField] private bool equippedItem;
+        [SerializeField] private bool savedGame;
+
+        private void Start() => Refresh();
+
+        public void SetQuestAccepted() { questAccepted = true; Refresh(); }
+        public void SetEnteredHunt() { enteredHunt = true; Refresh(); }
+        public void SetKilledTarget() { killedTarget = true; Refresh(); }
+        public void SetPickedLoot() { pickedLoot = true; Refresh(); }
+        public void SetReturnedHub() { returnedHub = true; Refresh(); }
+        public void SetCraftedItem() { craftedItem = true; Refresh(); }
+        public void SetEquippedItem() { equippedItem = true; Refresh(); }
+        public void SetSavedGame() { savedGame = true; Refresh(); }
+
+        private void Refresh()
+        {
+            if (checklistText == null) return;
+            checklistText.text =
+                $"[ {(questAccepted ? 'x' : ' ')} ] Accepted Quest\n" +
+                $"[ {(enteredHunt ? 'x' : ' ')} ] Entered Hunt\n" +
+                $"[ {(killedTarget ? 'x' : ' ')} ] Killed Target\n" +
+                $"[ {(pickedLoot ? 'x' : ' ')} ] Picked Loot\n" +
+                $"[ {(returnedHub ? 'x' : ' ')} ] Returned to Hub\n" +
+                $"[ {(craftedItem ? 'x' : ' ')} ] Crafted Item\n" +
+                $"[ {(equippedItem ? 'x' : ' ')} ] Equipped Item\n" +
+                $"[ {(savedGame ? 'x' : ' ')} ] Saved Game";
+        }
+    }
+}

--- a/Assets/Scripts/UI/Panels/EquipmentPanelUI.cs
+++ b/Assets/Scripts/UI/Panels/EquipmentPanelUI.cs
@@ -1,0 +1,57 @@
+using TinyHunter.Core.Equipment;
+using TinyHunter.Data.Items;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI.Panels
+{
+    public class EquipmentPanelUI : MonoBehaviour
+    {
+        [SerializeField] private EquipmentSystem equipment;
+        [SerializeField] private GameObject panelRoot;
+        [SerializeField] private Text weaponText;
+        [SerializeField] private Text headText;
+        [SerializeField] private InventoryPanelUI inventoryPanel;
+
+        private void Start()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+            if (equipment != null) equipment.OnEquipmentChanged += Refresh;
+            Refresh();
+        }
+
+        public bool IsOpen => panelRoot != null && panelRoot.activeSelf;
+
+        public void Toggle()
+        {
+            if (panelRoot == null) return;
+            panelRoot.SetActive(!panelRoot.activeSelf);
+            Refresh();
+        }
+
+        public void Close()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+        }
+
+        public void Refresh()
+        {
+            if (weaponText != null)
+            {
+                weaponText.text = equipment != null && equipment.EquippedWeapon != null
+                    ? $"Weapon: {equipment.EquippedWeapon.DisplayName}"
+                    : "Weapon: None";
+            }
+
+            if (headText != null)
+            {
+                headText.text = equipment != null && equipment.EquippedHead != null
+                    ? $"Head: {equipment.EquippedHead.DisplayName}"
+                    : "Head: None";
+            }
+        }
+
+        public void EquipWeapon(WeaponDefinition weapon) => equipment?.EquipWeapon(weapon);
+        public void EquipHead(ArmorDefinition armor) => equipment?.EquipArmor(armor);
+    }
+}

--- a/Assets/Scripts/UI/Panels/InventoryPanelUI.cs
+++ b/Assets/Scripts/UI/Panels/InventoryPanelUI.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using TinyHunter.Core.Inventory;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI.Panels
+{
+    public class InventoryPanelUI : MonoBehaviour
+    {
+        [SerializeField] private GameObject panelRoot;
+        [SerializeField] private InventorySystem inventory;
+        [SerializeField] private Text contentText;
+
+        public bool IsOpen => panelRoot != null && panelRoot.activeSelf;
+
+        private void Start()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+            Refresh();
+            if (inventory != null) inventory.OnItemChanged += (_, _) => Refresh();
+        }
+
+        public void Toggle()
+        {
+            if (panelRoot == null) return;
+            panelRoot.SetActive(!panelRoot.activeSelf);
+            Refresh();
+        }
+
+        public void Close()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+        }
+
+        public void Refresh()
+        {
+            if (contentText == null || inventory == null) return;
+
+            StringBuilder sb = new();
+            foreach (var entry in inventory.Entries)
+            {
+                if (entry.Item == null) continue;
+                sb.AppendLine($"- {entry.Item.DisplayName} x{entry.Quantity}");
+            }
+
+            contentText.text = sb.Length == 0 ? "Inventory Empty" : sb.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Panels/PauseMenuUI.cs
+++ b/Assets/Scripts/UI/Panels/PauseMenuUI.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace TinyHunter.UI.Panels
+{
+    public class PauseMenuUI : MonoBehaviour
+    {
+        [SerializeField] private GameObject panelRoot;
+        [SerializeField] private GameObject deathLabel;
+
+        public bool IsOpen => panelRoot != null && panelRoot.activeSelf;
+
+        private void Start()
+        {
+            Close();
+            if (deathLabel != null) deathLabel.SetActive(false);
+        }
+
+        public void TogglePause()
+        {
+            if (panelRoot == null) return;
+            bool next = !panelRoot.activeSelf;
+            panelRoot.SetActive(next);
+            Time.timeScale = next ? 0f : 1f;
+        }
+
+        public void Close()
+        {
+            if (panelRoot != null) panelRoot.SetActive(false);
+            Time.timeScale = 1f;
+        }
+
+        public void ShowDeathState()
+        {
+            if (panelRoot != null) panelRoot.SetActive(true);
+            if (deathLabel != null) deathLabel.SetActive(true);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Panels/UIInputRouter.cs
+++ b/Assets/Scripts/UI/Panels/UIInputRouter.cs
@@ -1,0 +1,70 @@
+using TinyHunter.Core.Input;
+using TinyHunter.Core.Player;
+using TinyHunter.Core.Save;
+using UnityEngine;
+
+namespace TinyHunter.UI.Panels
+{
+    public class UIInputRouter : MonoBehaviour
+    {
+        [SerializeField] private PlayerInputReader input;
+        [SerializeField] private PlayerController playerController;
+        [SerializeField] private InventoryPanelUI inventoryPanel;
+        [SerializeField] private EquipmentPanelUI equipmentPanel;
+        [SerializeField] private PauseMenuUI pauseMenu;
+        [SerializeField] private TinyHunter.UI.CraftingPanelUI craftingPanel;
+        [SerializeField] private SaveSystem saveSystem;
+        [SerializeField] private DebugChecklistUI checklist;
+
+        private void Update()
+        {
+            if (input == null) return;
+
+            if (input.InventoryTogglePressed)
+            {
+                inventoryPanel?.Toggle();
+                equipmentPanel?.Toggle();
+                SyncPlayerInteraction();
+            }
+
+            if (input.EscapePressed)
+            {
+                if (craftingPanel != null && craftingPanel.IsOpen)
+                {
+                    craftingPanel.Close();
+                }
+                else if (inventoryPanel != null && inventoryPanel.IsOpen)
+                {
+                    inventoryPanel.Close();
+                    equipmentPanel?.Close();
+                }
+                else
+                {
+                    pauseMenu?.TogglePause();
+                }
+
+                SyncPlayerInteraction();
+            }
+
+            if (input.SavePressed)
+            {
+                saveSystem?.SaveGame();
+                checklist?.SetSavedGame();
+            }
+
+            if (input.LoadPressed)
+            {
+                saveSystem?.LoadGame();
+            }
+        }
+
+        private void SyncPlayerInteraction()
+        {
+            bool anyPanel = (craftingPanel != null && craftingPanel.IsOpen)
+                            || (inventoryPanel != null && inventoryPanel.IsOpen)
+                            || (equipmentPanel != null && equipmentPanel.IsOpen)
+                            || (pauseMenu != null && pauseMenu.IsOpen);
+            playerController?.SetInteractionState(anyPanel);
+        }
+    }
+}

--- a/Assets/Scripts/UI/PlayerHUD.cs
+++ b/Assets/Scripts/UI/PlayerHUD.cs
@@ -1,0 +1,45 @@
+using TinyHunter.Core.Combat;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI
+{
+    public class PlayerHUD : MonoBehaviour
+    {
+        [SerializeField] private PlayerStats playerStats;
+        [SerializeField] private TargetLockSystem lockSystem;
+        [SerializeField] private Slider healthBar;
+        [SerializeField] private Slider staminaBar;
+        [SerializeField] private Text targetText;
+
+        private void OnEnable()
+        {
+            if (playerStats == null) return;
+            playerStats.OnHealthChanged += UpdateHealth;
+            playerStats.OnStaminaChanged += UpdateStamina;
+        }
+
+        private void OnDisable()
+        {
+            if (playerStats == null) return;
+            playerStats.OnHealthChanged -= UpdateHealth;
+            playerStats.OnStaminaChanged -= UpdateStamina;
+        }
+
+        private void Update()
+        {
+            if (targetText == null || lockSystem == null) return;
+            targetText.text = lockSystem.CurrentTarget == null ? "Target: None" : $"Target: {lockSystem.CurrentTarget.name}";
+        }
+
+        private void UpdateHealth(float current, float max)
+        {
+            if (healthBar != null) healthBar.value = max <= 0f ? 0f : current / max;
+        }
+
+        private void UpdateStamina(float current, float max)
+        {
+            if (staminaBar != null) staminaBar.value = max <= 0f ? 0f : current / max;
+        }
+    }
+}

--- a/Assets/Scripts/UI/QuestHUD.cs
+++ b/Assets/Scripts/UI/QuestHUD.cs
@@ -1,0 +1,46 @@
+using TinyHunter.Core.Quest;
+using TinyHunter.Data.Quests;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI
+{
+    public class QuestHUD : MonoBehaviour
+    {
+        [SerializeField] private QuestSystem questSystem;
+        [SerializeField] private Text activeQuestText;
+        [SerializeField] private Text progressText;
+
+        private void OnEnable()
+        {
+            if (questSystem == null) return;
+            questSystem.OnQuestAccepted += HandleQuestAccepted;
+            questSystem.OnQuestProgressChanged += HandleProgress;
+            questSystem.OnQuestCompleted += HandleCompleted;
+        }
+
+        private void OnDisable()
+        {
+            if (questSystem == null) return;
+            questSystem.OnQuestAccepted -= HandleQuestAccepted;
+            questSystem.OnQuestProgressChanged -= HandleProgress;
+            questSystem.OnQuestCompleted -= HandleCompleted;
+        }
+
+        private void HandleQuestAccepted(QuestDefinition quest)
+        {
+            if (activeQuestText != null) activeQuestText.text = $"Quest: {quest.DisplayName}";
+            if (progressText != null) progressText.text = $"Progress: 0/{quest.TargetCount}";
+        }
+
+        private void HandleProgress(QuestDefinition quest, int current, int target)
+        {
+            if (progressText != null) progressText.text = $"Progress: {current}/{target}";
+        }
+
+        private void HandleCompleted(QuestDefinition quest)
+        {
+            if (progressText != null) progressText.text = $"Completed: {quest.DisplayName}";
+        }
+    }
+}

--- a/Assets/Scripts/UI/RecipeEntryUI.cs
+++ b/Assets/Scripts/UI/RecipeEntryUI.cs
@@ -1,0 +1,66 @@
+using TinyHunter.Core.Crafting;
+using TinyHunter.Data.Crafting;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TinyHunter.UI
+{
+    public class RecipeEntryUI : MonoBehaviour
+    {
+        [SerializeField] private Text recipeName;
+        [SerializeField] private Text requirements;
+        [SerializeField] private Button craftButton;
+
+        private CraftingRecipeDefinition recipe;
+        private CraftingSystem craftingSystem;
+
+        public void Bind(CraftingRecipeDefinition recipeDef, CraftingSystem system)
+        {
+            recipe = recipeDef;
+            craftingSystem = system;
+
+            if (recipeName != null) recipeName.text = recipe.DisplayName;
+            if (requirements != null) requirements.text = BuildRequirementsText(recipe);
+
+            craftButton.onClick.RemoveAllListeners();
+            craftButton.onClick.AddListener(Craft);
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            if (craftButton != null && craftingSystem != null && recipe != null)
+            {
+                craftButton.interactable = craftingSystem.CanCraft(recipe);
+            }
+        }
+
+
+        public bool TryCraftViaHotkey()
+        {
+            if (craftingSystem == null || recipe == null) return false;
+            if (!craftingSystem.CanCraft(recipe)) return false;
+            Craft();
+            return true;
+        }
+        private void Craft()
+        {
+            if (craftingSystem.Craft(recipe))
+            {
+                Refresh();
+            }
+        }
+
+        private static string BuildRequirementsText(CraftingRecipeDefinition recipeDef)
+        {
+            string text = string.Empty;
+            foreach (var cost in recipeDef.Costs)
+            {
+                if (cost.Item == null) continue;
+                text += $"{cost.Item.DisplayName} x{cost.Amount}\n";
+            }
+
+            return text.TrimEnd();
+        }
+    }
+}

--- a/Docs/CharacterCreator_Preparation.md
+++ b/Docs/CharacterCreator_Preparation.md
@@ -1,0 +1,104 @@
+# Tiny Hunter - Character Creator Preparation (Dormant Foundation)
+
+This document explains what is prepared now for a **future** character creator and what is **not active yet**.
+
+## Current status
+- ✅ Data model for appearance exists.
+- ✅ `CharacterCustomizer` component exists and is safe to keep dormant.
+- ✅ Save data is forward-compatible with appearance profile info.
+- ✅ Asset naming conventions and prefab hierarchy are documented.
+- ❌ No creator UI/menu flow is active yet.
+- ❌ No forced character creation step at game start.
+
+## Data model prepared
+- `CharacterAppearanceData`
+  - `CharacterName`
+  - `SexIndex` (0 male, 1 female)
+  - `BodyTypeIndex` (0 normal, 1 slim, 2 strong, 3 heavy)
+  - `HeadPresetIndex`
+  - `HairPresetIndex`
+  - `SkinToneIndex`
+  - `HairColorIndex`
+- `PlayerProfileData`
+  - `Appearance`
+
+## Dormant customizer component
+Script: `CharacterCustomizer`
+
+Prepared hooks:
+- `bodyRoot`, `headRoot`, `hairSocket`
+- male/female body preset arrays
+- head preset array
+- hair preset array
+- skin/hair color palette arrays
+
+Current behavior:
+- Does not affect gameplay loop unless manually used.
+- Can safely apply only skin/hair color if configured.
+- `applyOnStart` defaults to off for non-invasive behavior.
+
+## Expected future player visual hierarchy
+Use this structure when you are ready to add final character visuals:
+
+```text
+CharacterRoot
+  VisualRoot
+    BodyRoot
+    HeadRoot
+    HairSocket
+    Armor_Head
+    Armor_Chest
+    Armor_Arms
+    Armor_Waist
+    Armor_Legs
+```
+
+This keeps body/head/hair modular and armor-ready.
+
+## Future asset naming convention
+### Body presets
+- `Male_Normal`
+- `Male_Slim`
+- `Male_Strong`
+- `Male_Heavy`
+- `Female_Normal`
+- `Female_Slim`
+- `Female_Strong`
+- `Female_Heavy`
+
+### Head presets
+- `HeadPreset_01`
+- `HeadPreset_02`
+- `HeadPreset_03`
+- `HeadPreset_04`
+- `HeadPreset_05`
+
+### Hair presets
+- `Hair_01`
+- `Hair_02`
+- `Hair_03`
+- `Hair_04`
+- `Hair_05`
+- `Hair_06`
+
+## Save/load compatibility prepared
+`SaveData` now includes `PlayerProfileData profile`.
+
+Meaning:
+- Existing saves can continue to work.
+- Future creator selections can be stored without redesigning the save format.
+
+## What to do later to activate character creator
+1. Build a creator UI (name, sex, body type, head preset, hair preset, skin tone, hair color).
+2. Add a creator scene or menu panel.
+3. Fill `CharacterCustomizer` arrays with final body/head/hair assets.
+4. Feed chosen values into `PlayerProfileData.Appearance`.
+5. Save and load that profile through `SaveSystem`.
+6. Call `CharacterCustomizer.ApplyAppearance(...)` when spawning player.
+7. Optionally add preview camera and rotate character in creator UI.
+
+## Intentionally not implemented yet
+- No sliders/blendshape facial editor.
+- No runtime body/head swap UI.
+- No forced startup character creation flow.
+- No additional complexity that can break current MVP.

--- a/Docs/Platform_Readiness_Guide.md
+++ b/Docs/Platform_Readiness_Guide.md
@@ -1,0 +1,116 @@
+# Tiny Hunter - Platform Readiness Guide (PC First, Mobile Ready Later)
+
+This pass keeps Tiny Hunter **PC-first playable** while preparing architecture for future Android/iOS adaptation.
+
+## 1) Input architecture readiness
+
+### Current setup
+- `PlayerInputReader` is now an input facade.
+- `DesktopInputSource` provides the current PC control scheme.
+- `MobileInputSourceStub` exists as future touch extension point.
+
+### Why this helps
+Gameplay scripts read from `PlayerInputReader`, not directly from `UnityEngine.Input`. This reduces rework when adding touch controls.
+
+### Current PC mapping
+- WASD: Move
+- Mouse: Camera look
+- LMB: Attack
+- RMB: Guard
+- Left Shift: Dodge
+- Space: Jump
+- C: Crouch
+- E: Interact/confirm
+- R: Lock-on toggle
+- Tab: Inventory/Equipment toggle
+- Escape: Pause/close panels
+- F5/F9: Save/Load debug
+
+### Future mobile mapping (proposal)
+- Left virtual stick: Move
+- Right drag zone: Camera look
+- Attack button
+- Guard button
+- Dodge button
+- Interact button
+- Lock-on button
+- Jump button
+- Crouch button
+- Optional pause/settings button
+
+`MobileInputSourceStub` is where UI button events should feed gameplay input later.
+
+## 2) UI scaling / responsiveness readiness
+
+### Current preparation
+- Add `AdaptiveCanvasScaler` to each gameplay canvas.
+- `AdaptiveCanvasScaler` applies `ScaleWithScreenSize` and platform-specific `matchWidthOrHeight`.
+- Uses reference resolution `1920x1080` by default.
+
+### Anchor/layout guidance
+- Keep core HUD anchored to corners (health top-left, quest top-right, prompts bottom-center).
+- Keep large panels centered with margins.
+- Avoid fixed pixel offsets near notches/safe areas for phone layouts.
+
+## 3) Platform config foundation
+
+### New data object
+`GamePlatformSettings` ScriptableObject:
+- PC tuning (target FPS, quality level, UI scale matching, recommended enemy budget)
+- Mobile tuning (lower quality/FPS defaults, mobile-leaning UI scale match)
+
+### Runtime application
+`PlatformBootstrap` applies:
+- `Application.targetFrameRate`
+- `QualitySettings` level
+
+This keeps platform divergence in data instead of hardcoded logic.
+
+## 4) Performance awareness (mobile-oriented notes)
+
+Prepared by architecture/docs:
+- Mobile profile defaults to lower quality and frame target.
+- Enemy budget documented in platform settings.
+- Input abstraction minimizes expensive per-platform branching in gameplay scripts.
+
+Still recommended later:
+- Reduce post-processing for mobile.
+- Use LODs for creatures/player visuals.
+- Keep active enemy count modest in mobile hunts.
+- Simplify VFX and reduce transparent overdraw.
+
+## 5) Build preparation notes (not full publishing)
+
+### Windows (PC)
+Later steps:
+1. Add `Windows` build target.
+2. Set resolution defaults and fullscreen mode.
+3. Build and run local executable.
+
+### Android
+Later steps:
+1. Switch to Android platform in Build Settings.
+2. Configure package ID + min/target SDK.
+3. Add touch UI and wire to `MobileInputSourceStub`.
+4. Test performance profile + UI scale on real devices.
+
+### iOS
+Later steps:
+1. Switch to iOS platform in Build Settings.
+2. Configure bundle identifier/signing in Xcode.
+3. Add touch UI and safe-area adjustments.
+4. Validate performance profile on iPhone hardware.
+
+## 6) What is prepared vs postponed
+
+### Prepared now
+- Input abstraction for desktop vs mobile source swapping.
+- Platform config ScriptableObject and runtime bootstrap hooks.
+- Adaptive canvas scaling hook for multi-resolution behavior.
+- Documentation for controls, mobile layout proposal, and build paths.
+
+### Intentionally postponed
+- Final touch control UI implementation.
+- Safe-area specific iPhone layout pass.
+- Store packaging/signing/certificates.
+- Full graphics optimization pass for production mobile performance.

--- a/Docs/TinyHunter_MVP_GDD.md
+++ b/Docs/TinyHunter_MVP_GDD.md
@@ -1,0 +1,189 @@
+# Tiny Hunter - Production Foundation (Unity/C#)
+
+## 1) High-level game vision summary
+Tiny Hunter is a third-person 3D action-hunting game where the player is a **2 mm-tall human hunter** navigating a modern house as a lethal macro-scale wilderness. The game loop is intentionally Monster Hunter-like: prepare loadout, track target, fight a high-threat arthropod, break specific body parts, harvest anatomical materials, and craft stronger equipment at a safe hub.
+
+The fantasy is grounded: familiar domestic spaces (kitchen tile, cabinet gaps, sink runoff, crumbs, dust, and clutter) become traversal and combat challenges at miniature human scale.
+
+## 2) Core gameplay pillars
+1. **Hunting**: tracking and challenging real-time boss-like insect encounters.
+2. **Preparation**: gear, resistances, consumables, and route planning before departure.
+3. **Anatomical progression**: parts and organs unlock weapon/armor branches.
+4. **Scale-first exploration**: every room is realistic, but transformed by perspective.
+5. **High tension**: player fragility, readable enemy attacks, stamina/positioning decisions.
+6. **Grounded domestic ecology**: creature behavior tied to moisture, darkness, crumbs, and nesting.
+
+## 3) Worldbuilding and scale rules
+- Player is always around **2 mm tall**; do not treat them as microscopic.
+- Household assets remain recognizable and realistic.
+- Terrain conversions at this scale:
+  - Dust = loose debris field.
+  - Crumb = carryable resource and partial cover.
+  - Tile seam = trench/crevice.
+  - Water droplet = impact hazard.
+  - Small puddle = route blocker unless equipped.
+  - Cabinet toe-kick gap = tunnel system.
+- Keep naming and visual language non-comedic and non-whimsical.
+
+## 4) Main areas of the house and design rules
+- **Kitchen (MVP combat zone)**: crumbs, sink splash, grease streaks, under-cabinet darkness; ant and spider overlaps.
+- **Bathroom**: humidity, drain suction risk, soap slip lanes, silverfish/mosquito habitats.
+- **Bedroom**: under-bed predator routes, textile folds for stealth, cable crossing lines.
+- **Living room**: carpet friction terrain, warm electronics, sofa underside nests.
+- **Hallway**: fast-travel connector with periodic airflow hazards.
+- **Laundry**: heat/vibration hazards near appliances, roach activity corridors.
+- **Garage**: dry dust, oils, metallic scrap for late-tier weapon crafting.
+- **Patio/Garden**: open arena-style hunts, larger beetles and mantis classes.
+
+## 5) Creature roster (early/mid/late)
+### Early
+- **Ant Worker/Ant Soldier** (group pressure, route denial).
+- **House Spider (small)** (web traps, ambush).
+- **Silverfish** (fast nuisance, gather quest target).
+
+### Mid
+- **Cockroach** (armored sprinter, hard stagger).
+- **Wasp Scout** (aerial dive attacker).
+- **Cricket** (burst displacement attacks).
+
+### Late
+- **Widow Spider** (arena control, venom focus).
+- **Wasp Matriarch** (air superiority + summon behavior).
+- **Mantis Stalker** (duel boss, long windup precision strikes).
+
+## 6) Combat system design
+- Third-person lock-on, stamina-gated offense/defense.
+- Light/heavy attacks with recovery windows.
+- Directional dodge with i-frame tuning by gear.
+- Weak-point multiplier and damage-type matching.
+- **Part break system** with separate durability pools.
+- Status channels: poison, acid, impact trauma, water stagger.
+- Time-to-kill target: 4–8 minutes for MVP major hunts.
+
+## 7) Weapon classes
+1. **Needle Spear**: reach + precise weak-point pressure.
+2. **Pin Blade**: fast, low commitment, ideal for evasive targets.
+3. **Button Hammer**: slow blunt breaker (future milestone).
+4. **Staple Bow**: anti-air option (post-MVP).
+5. **Razor Shard Axe**: sever-centric hybrid (post-MVP).
+
+MVP ships with Needle Spear + Pin Blade.
+
+## 8) Armor and crafting progression
+- Slots: Head/Chest/Arms/Waist/Legs.
+- Ant set: traction + stagger resistance.
+- Spider set: poison mitigation + web slow resistance.
+- Armor stats influence movement/stamina handling instead of pure HP inflation.
+- Crafting requires anatomical drops plus household scrap/fiber binders.
+
+## 9) Hunt loop and quest flow
+1. Accept quest at hub board.
+2. Equip weapon, armor, consumables.
+3. Enter kitchen route instance.
+4. Track signs (pheromone trail, web anchors).
+5. Fight target; break relevant parts.
+6. Harvest rewards.
+7. Return to hub.
+8. Craft or upgrade.
+9. Unlock next hunt tier.
+
+## 10) Hub/base design
+**Wall-void refuge near kitchen utility line**:
+- Craft bench (forge equivalent).
+- Quest board.
+- Storage trunk.
+- NPCs: scout, fabricator, anatomist, quartermaster.
+- Training lane with dummy insect carapace targets.
+
+## 11) Technical architecture in Unity
+Layered modular architecture:
+- **Data layer**: ScriptableObjects for definitions.
+- **Runtime systems**: inventory, combat, part break, crafting, quests.
+- **Presentation layer**: camera, animation hooks, VFX/SFX events.
+
+Avoid monoliths: each concern has dedicated component and clear interfaces (`IDamageable`).
+
+## 12) Recommended folder structure
+```text
+Assets/
+  Scripts/
+    Core/
+      Player/
+      Camera/
+      Combat/
+      Inventory/
+      Crafting/
+      Quest/
+      Equipment/
+      Hub/
+      Save/
+    Data/
+      Combat/
+      Items/
+      Monsters/
+      Crafting/
+      Quests/
+    MVP/
+      Enemies/
+Docs/
+  TinyHunter_MVP_GDD.md
+```
+
+## 13) ScriptableObject data model proposal
+- `ItemDefinition` (all item primitives).
+- `WeaponDefinition` / `ArmorDefinition`.
+- `MonsterDefinition` (stats, ecology, parts, weakness).
+- `MonsterPartDefinition` (part durability + break reward/effect).
+- `LootTableDefinition` (`LootEntry` rarity/chance/amount).
+- `CraftingRecipeDefinition` (`MaterialCost[]`, unlock condition).
+- `QuestDefinition` (objective, target, timer, reward).
+
+## 14) MVP scope
+Playable target in 1 scene + 1 hub:
+- Hub with quest accept + crafting station.
+- Kitchen floor/lower cabinet hunt arena.
+- Creatures: Ant Soldier + Spider.
+- Weapons: Needle Spear + Pin Blade.
+- Systems: third-person movement, lock-on, stamina, combat hits, part breaks, loot, inventory, crafting, basic quest completion.
+
+## 15) Step-by-step implementation plan
+1. Create ScriptableObject classes (items/monsters/quests/crafting).
+2. Implement `InventorySystem`, `CraftingSystem`, `QuestSystem`.
+3. Build player core: `PlayerStats`, `PlayerController`, lock-on, camera.
+4. Build combat core: `WeaponCombatSystem`, `IDamageable`.
+5. Build enemy health and part break systems.
+6. Implement Ant Soldier AI and Spider ambush AI.
+7. Set up kitchen graybox arena and navmesh.
+8. Author initial SO assets for ant/spider drops and recipes.
+9. Connect quest completion to monster defeat events.
+10. Add UI pass (HP/stamina, lock target, quest progress, inventory/craft panel).
+11. Balance pass for stamina drain, dodge windows, TTK.
+
+## 16) Initial C# scripts for MVP
+Implemented in repository:
+- Core player/camera/combat/inventory/crafting/quest scripts.
+- ScriptableObject definitions for all MVP data domains.
+
+## 17) Example enemy implementation
+- `AntSoldierAI`: chase + bite cooldown, tuned for pressure combat.
+- `SpiderAmbushAI`: hidden hold, trigger radius, lunge + venom burst behavior.
+
+## 18) Example crafting recipe setup
+**Needle Spear Mk1** (unlock: first Ant Soldier slay)
+- 4x Chitin Shard (common)
+- 2x Mandible Edge (uncommon)
+- 1x Thread Fiber (common)
+- 1x Metal Splinter (common)
+
+**Spider Hood** (unlock: first Spider slay)
+- 3x Silk Gland (common)
+- 1x Fang Shard (rare)
+- 2x Dust Resin Clump (common)
+
+## 19) Suggestions for future expansion
+- Turf interactions (ant vs spider territorial fights).
+- Environmental traps (water droplet timing, fan airflow windows).
+- Capture tools (thread net, sedative resin).
+- Multi-room expedition chains.
+- Advanced AI sensing (pheromone, vibration, light aversion).
+- Co-op (2 hunters) with role-specialized loadouts.

--- a/Docs/Tutorials/Beginner_Model_Animation_Import_Tutorial.md
+++ b/Docs/Tutorials/Beginner_Model_Animation_Import_Tutorial.md
@@ -1,0 +1,201 @@
+# Tiny Hunter Beginner Tutorial (Very Simple)
+
+This tutorial is written for beginners. Imagine you are 12 and adding assets for the first time.
+
+You will learn how to add:
+- player models (male + female)
+- creature models (ant, spider)
+- animations
+- prefab links
+
+Do not worry. Go step by step.
+
+---
+
+## 1) Before you start
+
+You need:
+- Unity project open
+- Your model files (`.fbx` is common)
+- Texture files (`.png`, `.tga`, etc.)
+- Animation files (`.fbx` or `.anim`)
+
+Make folders in Unity Project panel:
+
+```text
+Assets/
+  Art/
+    Characters/
+      Male/
+      Female/
+    Creatures/
+      Ant/
+      Spider/
+    Materials/
+    Textures/
+    Animations/
+```
+
+---
+
+## 2) Import player models (male/female)
+
+1. Drag your male model file into `Assets/Art/Characters/Male`.
+2. Drag your female model file into `Assets/Art/Characters/Female`.
+3. Click model file in Unity.
+4. In Inspector, check:
+   - **Rig** tab
+   - Animation Type = `Humanoid` (or `Generic` if your model is not humanoid-rigged)
+5. Press **Apply**.
+
+Tip: If rig errors appear, use `Generic` first so you can keep moving.
+
+---
+
+## 3) Import creature models (ant/spider)
+
+1. Drag ant files into `Assets/Art/Creatures/Ant`.
+2. Drag spider files into `Assets/Art/Creatures/Spider`.
+3. Set Rig = `Generic` for most creature rigs.
+4. Press **Apply**.
+
+---
+
+## 4) Create materials
+
+1. Right click `Assets/Art/Materials` -> Create -> Material.
+2. Make materials like:
+   - `MAT_MaleBody`
+   - `MAT_FemaleBody`
+   - `MAT_Ant`
+   - `MAT_Spider`
+3. Drag textures into material slots (Base Map, Normal, etc.).
+4. Drag materials onto model meshes.
+
+---
+
+## 5) Import animations
+
+1. Put player animations in `Assets/Art/Animations/Player`.
+2. Put ant animations in `Assets/Art/Animations/Ant`.
+3. Put spider animations in `Assets/Art/Animations/Spider`.
+4. Select each animation source file.
+5. In Inspector -> Animations tab, verify clips exist.
+
+Player clips you usually want:
+- Idle
+- Walk/Run
+- LightAttack
+- HeavyAttack
+- Dodge
+- Hit
+- Death
+
+Creature clips you usually want:
+- Idle
+- Move
+- Attack
+- Hit
+- Death
+
+---
+
+## 6) Build the player visual hierarchy (important)
+
+Inside your player prefab, make this structure:
+
+```text
+CharacterRoot
+  VisualRoot
+    BodyRoot
+    HeadRoot
+    HairSocket
+    Armor_Head
+    Armor_Chest
+    Armor_Arms
+    Armor_Waist
+    Armor_Legs
+```
+
+Put your body mesh under `BodyRoot`.
+Put head mesh under `HeadRoot`.
+Put hair under `HairSocket`.
+
+---
+
+## 7) Add CharacterCustomizer (future-ready)
+
+1. Select player prefab root.
+2. Add `CharacterCustomizer` component.
+3. Assign:
+   - `bodyRoot`
+   - `headRoot`
+   - `hairSocket`
+4. Keep `applyOnStart = false` for now (very important, so MVP flow stays stable).
+5. Optionally set skin/hair color palettes.
+
+---
+
+## 8) Add Animator safely
+
+1. Add `Animator` to player visual root.
+2. Create an Animator Controller:
+   - `AC_Player`
+3. Add parameters/triggers:
+   - `LightAttack`
+   - `HeavyAttack`
+   - `Dodge`
+   - `Hit`
+   - `Death`
+4. Assign `Animator` reference in `PlayerAnimationBridge`.
+
+If you don’t finish state machine now, it’s okay. Triggers can stay ready.
+
+---
+
+## 9) Make creature prefabs
+
+### Ant prefab
+- Add mesh + material
+- Keep AI scripts already in project
+- Add collider(s) and child `MonsterPartHitbox` objects:
+  - `head`
+  - `mandible`
+  - `leg`
+
+### Spider prefab
+- Add mesh + material
+- Keep AI scripts already in project
+- Add child `MonsterPartHitbox` objects:
+  - `fang`
+  - `abdomen`
+  - `leg`
+
+---
+
+## 10) Quick test checklist
+
+After importing, press Play and test:
+1. Player appears correctly.
+2. Ant and spider appear correctly.
+3. Attack can hit enemies.
+4. Loot still drops.
+5. No missing material (pink mesh).
+6. No missing script errors in Console.
+
+---
+
+## 11) Common beginner mistakes
+
+- **Pink model**: material/shader missing.
+- **Model too big/small**: set import scale in model import settings.
+- **No animation**: Animator controller not assigned.
+- **No hit detection**: forgot colliders or `MonsterPartHitbox` IDs.
+- **Character creator breaks MVP**: forgot to keep `applyOnStart` disabled.
+
+---
+
+## 12) When you are ready for full creator later
+
+Use `Docs/CharacterCreator_Preparation.md`.
+It tells you exactly how to activate the creator in steps.

--- a/Docs/Unity_MVP_Scene_Setup_Guide.md
+++ b/Docs/Unity_MVP_Scene_Setup_Guide.md
@@ -1,0 +1,150 @@
+# Tiny Hunter - MVP Second Pass Setup Guide (Unity)
+
+## Control Scheme (standardized)
+- **WASD**: Move
+- **Mouse**: Camera look
+- **Space**: Jump
+- **C**: Crouch toggle
+- **E**: Interact / pick up / confirm craft in crafting panel
+- **LMB**: Primary attack
+- **RMB**: Guard/block (if equipped weapon supports block)
+- **R**: Lock/Unlock target
+- **Left Shift**: Dodge roll
+- **Tab**: Toggle Inventory + Equipment panels
+- **Escape**: Close panels or open/close pause menu
+- **F5/F9**: Save/Load debug hotkeys
+
+Input is centralized in `PlayerInputReader` and consumed by gameplay/UI systems.
+
+## Scenes
+Create three scenes:
+1. `MainMenu`
+2. `Hub_MVP`
+3. `Kitchen_MVP`
+
+## Global bootstrap object (in MainMenu)
+Create `GameBootstrap` with:
+- `SceneFlowController`
+- `SaveSystem`
+
+Mark both as scene-persistent via built-in script behavior (`DontDestroyOnLoad`).
+
+## Player prefab (`PF_Player`)
+Required components:
+- `CharacterController`
+- `PlayerInputReader`
+- `PlayerStats`
+- `PlayerController`
+- `PlayerAnimationBridge`
+- `TargetLockSystem`
+- `WeaponCombatSystem`
+- `InventorySystem`
+- `EquipmentSystem`
+- `PlayerInteractionSystem`
+- `PlayerDeathHandler`
+
+Camera rig:
+- `ThirdPersonCameraController` (assign target + input)
+- Main Camera child with `CameraShake`
+
+## Core UI in Hub and Kitchen
+Canvas objects/scripts:
+- `PlayerHUD`
+- `QuestHUD`
+- `InteractionPromptUI`
+- `CraftingPanelUI`
+- `InventoryPanelUI`
+- `EquipmentPanelUI`
+- `DebugChecklistUI`
+- `PauseMenuUI`
+- `UIInputRouter`
+
+## Hub_MVP contents
+- Player spawn
+- `QuestBoard` (`QuestBoardInteractable`)
+- `CraftingBench` (`CraftingStationInteractable`)
+- `HuntGate` (`EnterHuntInteractable`)
+- storage placeholder
+
+## Kitchen_MVP contents
+- Player spawn
+- arena floor + cover clutter
+- ant spawn (`PF_AntSoldier`)
+- spider ambush spawn (`PF_Spider`)
+- return trigger (`HuntExitTrigger`)
+
+Bake NavMesh for enemy movement.
+
+## Enemy prefab wiring
+### Ant Soldier
+- `AntSoldierAI` + `MonsterHealth` + `MonsterPartBreakSystem` + `NavMeshAgent`
+- child hitbox colliders each with `MonsterPartHitbox` IDs: `head`, `mandible`, `leg`
+
+### Spider
+- `SpiderAmbushAI` + `MonsterHealth` + `MonsterPartBreakSystem` + `NavMeshAgent`
+- child hitbox IDs: `fang`, `abdomen`, `leg`
+
+## Data authoring
+Use ScriptableObjects for all data and create:
+- Item assets (drops + craft outputs)
+- ItemDatabase asset (all item defs)
+- Weapon/Armor defs
+- Monster part defs
+- Monster defs + loot tables
+- Quest defs
+- Crafting recipes
+
+## Save/load wiring
+`SaveSystem` needs:
+- `ItemDatabase`
+- known quest list for restore
+
+Save data includes:
+- inventory quantities
+- equipped weapon
+- equipped head armor
+- active quest id
+
+## Death/respawn loop
+- `PlayerDeathHandler` watches `PlayerStats.IsDead`
+- shows death pause state
+- after delay, returns player to `Hub_MVP`
+
+## What is testable now
+1. Main menu start/continue.
+2. Hub quest accept with `E`.
+3. Enter hunt scene.
+4. Standard third-person control + jump/crouch/dodge/guard.
+5. Lock-on with `R`.
+6. Kill enemies, break parts, pick up loot.
+7. Return to hub, craft, auto-equip crafted gear.
+8. Toggle inventory/equipment (`Tab`).
+9. Save (`F5`) and load (`F9`) or continue from menu.
+
+
+## Character creator (prepared, not active)
+This MVP includes dormant preparation only:
+- `CharacterAppearanceData`
+- `PlayerProfileData`
+- `CharacterCustomizer`
+
+Keep `CharacterCustomizer.applyOnStart` **disabled** so current gameplay flow remains unchanged.
+
+For full activation later, follow:
+- `Docs/CharacterCreator_Preparation.md`
+- `Docs/Tutorials/Beginner_Model_Animation_Import_Tutorial.md`
+
+
+## Platform readiness components (PC first)
+Add these optional components now for future PC/Android/iOS split:
+- `PlatformBootstrap` on a persistent bootstrap object
+- `AdaptiveCanvasScaler` on each gameplay canvas
+- `PlayerInputReader` sources:
+  - desktop source -> `DesktopInputSource`
+  - mobile source -> `MobileInputSourceStub` (future touch wiring)
+
+Create one `GamePlatformSettings` ScriptableObject and assign it to:
+- `PlatformBootstrap`
+- `AdaptiveCanvasScaler`
+
+Keep `PlayerInputReader.forceDesktopInput = true` during current MVP PC playtests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
-# Helloworld
+# Tiny Hunter MVP (Unity/C#)
 
-Hola a todos.
+This repository contains a playable PC-first MVP for a grounded 2 mm-scale third-person action-hunt prototype.
 
-Mi nombre es Alex y tengo 27 años. :D
+## Current gameplay scope
+- Hub -> Hunt -> Return loop
+- Third-person combat and lock-on
+- Part breaking and loot pickup
+- Crafting and equipment
+- Quest progression
+- Save/load and scene flow
+
+## Character creator status (important)
+A **future-ready, dormant** character creator foundation is prepared, but NOT active in current gameplay flow.
+
+Prepared now:
+- Appearance/profile data classes
+- `CharacterCustomizer` component hooks
+- Save compatibility for appearance profile data
+- Naming conventions + prefab hierarchy docs
+- Beginner-friendly model/animation import tutorial
+
+Not active yet:
+- No character creator UI screen
+- No forced creator at game start
+- No advanced facial morph/sliders
+
+## Platform readiness status (important)
+This pass prepares architecture for future PC/Android/iOS adaptation while keeping MVP PC-first.
+
+Prepared now:
+- Input source abstraction (`PlayerInputReader` + desktop/mobile source components)
+- Platform settings data profile (`GamePlatformSettings`)
+- Runtime platform bootstrap for quality/FPS defaults
+- Adaptive canvas scaling hook for cross-resolution UI behavior
+- Platform documentation and future build path notes
+
+Not active yet:
+- No final touch controls UI
+- No Android/iOS publishing/signing/store packaging
+- No full mobile optimization pass
+
+## Controls (PC)
+- WASD move, Mouse look
+- Space jump, C crouch
+- LMB attack, RMB guard
+- Left Shift dodge, R lock target
+- E interact/confirm
+- Tab inventory + equipment
+- Escape close/open pause
+- F5/F9 save/load debug
+
+## Setup docs
+- MVP scene setup: `Docs/Unity_MVP_Scene_Setup_Guide.md`
+- Creator preparation: `Docs/CharacterCreator_Preparation.md`
+- Beginner tutorial: `Docs/Tutorials/Beginner_Model_Animation_Import_Tutorial.md`
+- Platform readiness: `Docs/Platform_Readiness_Guide.md`


### PR DESCRIPTION
### Motivation
- Provide a complete foundation for the MVP gameplay loop (hub → hunt → return) by adding core runtime systems for combat, inventory, crafting, quests, and scene flow.
- Prepare extensibility for future features such as a character creator and mobile support by introducing forward-compatible appearance/profile data and platform/input abstraction.
- Centralize common services like save/load, equipment, and UI routing so authoring and playtesting can be done with minimal friction in the Editor.

### Description
- Added ScriptableObject data models for items, weapons, armor, monsters, monster parts, loot tables, crafting recipes, quests, and platform tuning (e.g. `ItemDefinition`, `WeaponDefinition`, `MonsterDefinition`, `QuestDefinition`, `CraftingRecipeDefinition`, `GamePlatformSettings`).
- Implemented core runtime systems including `InventorySystem`, `CraftingSystem`, `QuestSystem`, `EquipmentSystem`, `SaveSystem`, `SceneFlowController`, `PlayerInputReader` (with `DesktopInputSource` / `MobileInputSourceStub`), and platform helpers `PlatformBootstrap` and `AdaptiveCanvasScaler`.
- Added player and combat systems such as `PlayerController`, `PlayerStats`, `PlayerAnimationBridge`, `WeaponCombatSystem`, `HitFeedbackSystem`, `MonsterHealth`, `MonsterPartBreakSystem`, `IDamageable`, and supporting hitbox component `MonsterPartHitbox`.
- Introduced UI and interaction layers and MVP content including HUD/panels (`PlayerHUD`, `InventoryPanelUI`, `EquipmentPanelUI`, `CraftingPanelUI`, `QuestHUD`, `PauseMenuUI`, `UIInputRouter`, `InteractionPromptUI`), interaction systems (`PlayerInteractionSystem`, various `IInteractable` implementations), simple enemy AIs (`AntSoldierAI`, `SpiderAmbushAI`), world pickup logic, respawn/death handlers, camera helpers (`ThirdPersonCameraController`, `CameraShake`), and documentation (`Docs/*`) covering setup, platform readiness and character creator preparation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b032b3c820832cab4549afddcc3141)